### PR TITLE
EN #3183 allow null logs flag for python client

### DIFF
--- a/polyapi/cli.py
+++ b/polyapi/cli.py
@@ -66,13 +66,13 @@ def execute_from_cli():
     fn_add_parser.add_argument("--description", required=False, default="", help="Description of the function")
     fn_add_parser.add_argument("--server", action="store_true", help="Marks the function as a server function")
     fn_add_parser.add_argument("--client", action="store_true", help="Marks the function as a client function")
-    fn_add_parser.add_argument("--logs", choices=["enabled", "disabled"], default="disabled", help="Enable or disable logs for the function.")
+    fn_add_parser.add_argument("--logs", choices=["enabled", "disabled"], default=None, help="Enable or disable logs for the function.")
     fn_add_parser.add_argument("--execution-api-key", required=False, default="", help="API key for execution (for server functions only).")
     fn_add_parser.add_argument("--disable-ai", "--skip-generate", action="store_true", help="Pass --disable-ai skip AI generation of missing descriptions")
 
     def add_function(args):
         initialize_config()
-        logs_enabled = args.logs == "enabled"
+        logs_enabled = args.logs == "enabled" if args.logs else None
         err = ""
         if args.server and args.client:
             err = "Specify either `--server` or `--client`. Found both."

--- a/polyapi/function_cli.py
+++ b/polyapi/function_cli.py
@@ -1,5 +1,5 @@
 import sys
-from typing import Any, List
+from typing import Any, List, Optional
 import requests
 from polyapi.generate import get_functions_and_parse, generate_functions
 from polyapi.config import get_api_key_and_url
@@ -23,7 +23,7 @@ def function_add_or_update(
     description: str,
     client: bool,
     server: bool,
-    logs_enabled: bool,
+    logs_enabled: Optional[bool],
     generate: bool = True,
     execution_api_key: str = ""
 ):
@@ -45,6 +45,9 @@ def function_add_or_update(
         )
         sys.exit(1)
 
+    if logs_enabled is None:
+        logs_enabled = parsed["config"].get("logs_enabled", None)
+
     data = {
         "context": context or parsed["context"],
         "name": name,
@@ -54,7 +57,7 @@ def function_add_or_update(
         "returnType": get_jsonschema_type(return_type),
         "returnTypeSchema": parsed["types"]["returns"]["typeSchema"],
         "arguments": [{**p, "key": p["name"], "type": get_jsonschema_type(p["type"])  } for p in parsed["types"]["params"]],
-        "logsEnabled": logs_enabled or parsed["config"].get("logs_enabled", False),
+        "logsEnabled": logs_enabled,
     }
 
     if server and parsed["dependencies"]:


### PR DESCRIPTION
Allowing for null in py client will enable poly server to properly set logging enabled flag for new server functions. This makes the python client consistent with our TS client.