### PR TITLE
Some bug fixes for python client

### DIFF
--- a/polyapi/deployables.py
+++ b/polyapi/deployables.py
@@ -245,7 +245,7 @@ def update_deployment_comments(file_content: str, deployable: dict) -> str:
     if deployable['deployments']:
         deployment_comments = write_deploy_comments(deployable['deployments'])
         deployable['deploymentCommentRanges'] = [(0, len(deployment_comments) + 1)]
-        file_content = f"{deployment_comments}{file_content}"
+        file_content = f"{deployment_comments}\n{file_content}"
     return file_content
 
 def update_deployable_function_comments(file_content: str, deployable: dict, disable_docs: bool = False) -> str:

--- a/polyapi/function_cli.py
+++ b/polyapi/function_cli.py
@@ -55,7 +55,6 @@ def function_add_or_update(
         "code": code,
         "language": "python",
         "returnType": get_jsonschema_type(return_type),
-        "returnTypeSchema": parsed["types"]["returns"]["typeSchema"],
         "arguments": [{**p, "key": p["name"], "type": get_jsonschema_type(p["type"])  } for p in parsed["types"]["params"]],
         "logsEnabled": logs_enabled,
     }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.2", "wheel"]
 
 [project]
 name = "polyapi-python"
-version = "0.3.2.dev1"
+version = "0.3.2.dev2"
 description = "The Python Client for PolyAPI, the IPaaS by Developers for Developers"
 authors = [{ name = "Dan Fellin", email = "dan@polyapi.io" }]
 dependencies = [

--- a/tests/test_deployables.py
+++ b/tests/test_deployables.py
@@ -76,39 +76,48 @@ def foobar(foo: str, bar: Dict[str, str]) -> int:
 '''
 
 class T(unittest.TestCase):
-    def test_write_deployment_comment(self):
-        test_deployable = {
-            "deployments": [
-                {
-                    'context': 'testing',
-                    'deployed': '2024-11-12T14:43:22.631113',
-                    'fileRevision': '086aedd',
-                    'id': 'jh23h5g3h5b24jh5b2j3h45v2jhg43v52j3h',
-                    'instance': 'https://na1.polyapi.io',
-                    'name': 'foobar',
-                    'type': 'server-function'
-                },
-                {
-                    'context': 'testing',
-                    'deployed': '2024-11-11T14:43:22.631113',
-                    'fileRevision': '086aedd',
-                    'id': 'jh23h5g3h5b24jh5b2j3h45v2jhg43v52j3h',
-                    'instance': 'https://dev.polyapi.io',
-                    'name': 'foobar',
-                    'type': 'server-function'
-                }
-            ],
-            "deploymentCommentRanges": [[0, 178]]
-        }
-        updated_file_contents = update_deployment_comments(INITIAL_SERVER_FN_DEPLOYMENTS, test_deployable)
+    def test_parse_and_write_deployment_comment(self):
+        test_deployable = parse_function_code(EXPECTED_SERVER_FN_DEPLOYMENTS, "foobar")
+        deployable_comment_ranges = test_deployable["deploymentCommentRanges"]
+        updated_file_contents = update_deployment_comments(EXPECTED_SERVER_FN_DEPLOYMENTS, test_deployable)
         self.assertEqual(updated_file_contents, EXPECTED_SERVER_FN_DEPLOYMENTS)
+        # Deployment comment ranges collapsed into one of equal size
+        self.assertEqual(test_deployable["deploymentCommentRanges"][0][0], deployable_comment_ranges[0][0])
+        self.assertEqual(test_deployable["deploymentCommentRanges"][0][1], deployable_comment_ranges[1][1])
 
-    def test_parse_and_write_deployable_docstring(self):
-        parsed_deployable = parse_function_code(INITIAL_SERVER_FN_DOCSTRINGS)
-        updated_file_contents = update_deployable_function_comments(INITIAL_SERVER_FN_DOCSTRINGS, parsed_deployable)
-        self.assertEqual(updated_file_contents, EXPECTED_SERVER_FN_DOCSTRINGS)
+    # def test_write_deployment_comment(self):
+    #     test_deployable = {
+    #         "deployments": [
+    #             {
+    #                 'context': 'testing',
+    #                 'deployed': '2024-11-12T14:43:22.631113',
+    #                 'fileRevision': '086aedd',
+    #                 'id': 'jh23h5g3h5b24jh5b2j3h45v2jhg43v52j3h',
+    #                 'instance': 'https://na1.polyapi.io',
+    #                 'name': 'foobar',
+    #                 'type': 'server-function'
+    #             },
+    #             {
+    #                 'context': 'testing',
+    #                 'deployed': '2024-11-11T14:43:22.631113',
+    #                 'fileRevision': '086aedd',
+    #                 'id': 'jh23h5g3h5b24jh5b2j3h45v2jhg43v52j3h',
+    #                 'instance': 'https://dev.polyapi.io',
+    #                 'name': 'foobar',
+    #                 'type': 'server-function'
+    #             }
+    #         ],
+    #         "deploymentCommentRanges": [[0, 177]]
+    #     }
+    #     updated_file_contents = update_deployment_comments(INITIAL_SERVER_FN_DEPLOYMENTS, test_deployable)
+    #     self.assertEqual(updated_file_contents, EXPECTED_SERVER_FN_DEPLOYMENTS)
 
-    def test_parse_and_overwrite_docstring(self):
-        parsed_deployable = parse_function_code(EXPECTED_SERVER_FN_DOCSTRINGS)
-        updated_file_contents = update_deployable_function_comments(EXPECTED_SERVER_FN_DOCSTRINGS, parsed_deployable)
-        self.assertEqual(EXPECTED_SERVER_FN_DOCSTRINGS, updated_file_contents)
+    # def test_parse_and_write_deployable_docstring(self):
+    #     parsed_deployable = parse_function_code(INITIAL_SERVER_FN_DOCSTRINGS)
+    #     updated_file_contents = update_deployable_function_comments(INITIAL_SERVER_FN_DOCSTRINGS, parsed_deployable)
+    #     self.assertEqual(updated_file_contents, EXPECTED_SERVER_FN_DOCSTRINGS)
+
+    # def test_parse_and_overwrite_docstring(self):
+    #     parsed_deployable = parse_function_code(EXPECTED_SERVER_FN_DOCSTRINGS)
+    #     updated_file_contents = update_deployable_function_comments(EXPECTED_SERVER_FN_DOCSTRINGS, parsed_deployable)
+    #     self.assertEqual(EXPECTED_SERVER_FN_DOCSTRINGS, updated_file_contents)

--- a/tests/test_deployables.py
+++ b/tests/test_deployables.py
@@ -21,6 +21,7 @@ def foobar() -> int:
 
 EXPECTED_SERVER_FN_DEPLOYMENTS = '''# Poly deployed @ 2024-11-12T14:43:22.631113 - testing.foobar - https://na1.polyapi.io/canopy/polyui/collections/server-functions/jh23h5g3h5b24jh5b2j3h45v2jhg43v52j3h - 086aedd
 # Poly deployed @ 2024-11-11T14:43:22.631113 - testing.foobar - https://dev.polyapi.io/canopy/polyui/collections/server-functions/jh23h5g3h5b24jh5b2j3h45v2jhg43v52j3h - 086aedd
+
 from polyapi.typedefs import PolyServerFunction
 
 polyConfig: PolyServerFunction = {

--- a/tests/test_deployables.py
+++ b/tests/test_deployables.py
@@ -85,39 +85,39 @@ class T(unittest.TestCase):
         self.assertEqual(test_deployable["deploymentCommentRanges"][0][0], deployable_comment_ranges[0][0])
         self.assertEqual(test_deployable["deploymentCommentRanges"][0][1], deployable_comment_ranges[1][1])
 
-    # def test_write_deployment_comment(self):
-    #     test_deployable = {
-    #         "deployments": [
-    #             {
-    #                 'context': 'testing',
-    #                 'deployed': '2024-11-12T14:43:22.631113',
-    #                 'fileRevision': '086aedd',
-    #                 'id': 'jh23h5g3h5b24jh5b2j3h45v2jhg43v52j3h',
-    #                 'instance': 'https://na1.polyapi.io',
-    #                 'name': 'foobar',
-    #                 'type': 'server-function'
-    #             },
-    #             {
-    #                 'context': 'testing',
-    #                 'deployed': '2024-11-11T14:43:22.631113',
-    #                 'fileRevision': '086aedd',
-    #                 'id': 'jh23h5g3h5b24jh5b2j3h45v2jhg43v52j3h',
-    #                 'instance': 'https://dev.polyapi.io',
-    #                 'name': 'foobar',
-    #                 'type': 'server-function'
-    #             }
-    #         ],
-    #         "deploymentCommentRanges": [[0, 177]]
-    #     }
-    #     updated_file_contents = update_deployment_comments(INITIAL_SERVER_FN_DEPLOYMENTS, test_deployable)
-    #     self.assertEqual(updated_file_contents, EXPECTED_SERVER_FN_DEPLOYMENTS)
+    def test_write_deployment_comment(self):
+        test_deployable = {
+            "deployments": [
+                {
+                    'context': 'testing',
+                    'deployed': '2024-11-12T14:43:22.631113',
+                    'fileRevision': '086aedd',
+                    'id': 'jh23h5g3h5b24jh5b2j3h45v2jhg43v52j3h',
+                    'instance': 'https://na1.polyapi.io',
+                    'name': 'foobar',
+                    'type': 'server-function'
+                },
+                {
+                    'context': 'testing',
+                    'deployed': '2024-11-11T14:43:22.631113',
+                    'fileRevision': '086aedd',
+                    'id': 'jh23h5g3h5b24jh5b2j3h45v2jhg43v52j3h',
+                    'instance': 'https://dev.polyapi.io',
+                    'name': 'foobar',
+                    'type': 'server-function'
+                }
+            ],
+            "deploymentCommentRanges": [[0, 177]]
+        }
+        updated_file_contents = update_deployment_comments(INITIAL_SERVER_FN_DEPLOYMENTS, test_deployable)
+        self.assertEqual(updated_file_contents, EXPECTED_SERVER_FN_DEPLOYMENTS)
 
-    # def test_parse_and_write_deployable_docstring(self):
-    #     parsed_deployable = parse_function_code(INITIAL_SERVER_FN_DOCSTRINGS)
-    #     updated_file_contents = update_deployable_function_comments(INITIAL_SERVER_FN_DOCSTRINGS, parsed_deployable)
-    #     self.assertEqual(updated_file_contents, EXPECTED_SERVER_FN_DOCSTRINGS)
+    def test_parse_and_write_deployable_docstring(self):
+        parsed_deployable = parse_function_code(INITIAL_SERVER_FN_DOCSTRINGS)
+        updated_file_contents = update_deployable_function_comments(INITIAL_SERVER_FN_DOCSTRINGS, parsed_deployable)
+        self.assertEqual(updated_file_contents, EXPECTED_SERVER_FN_DOCSTRINGS)
 
-    # def test_parse_and_overwrite_docstring(self):
-    #     parsed_deployable = parse_function_code(EXPECTED_SERVER_FN_DOCSTRINGS)
-    #     updated_file_contents = update_deployable_function_comments(EXPECTED_SERVER_FN_DOCSTRINGS, parsed_deployable)
-    #     self.assertEqual(EXPECTED_SERVER_FN_DOCSTRINGS, updated_file_contents)
+    def test_parse_and_overwrite_docstring(self):
+        parsed_deployable = parse_function_code(EXPECTED_SERVER_FN_DOCSTRINGS)
+        updated_file_contents = update_deployable_function_comments(EXPECTED_SERVER_FN_DOCSTRINGS, parsed_deployable)
+        self.assertEqual(EXPECTED_SERVER_FN_DOCSTRINGS, updated_file_contents)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -3,6 +3,11 @@ import unittest
 from polyapi.parser import parse_function_code
 
 
+CODE_NO_TYPES = """
+def foobar(a, b):
+    return a + b
+"""
+
 SIMPLE_CODE = """
 def foobar(n: int) -> int:
     return 9
@@ -124,11 +129,21 @@ def foobar(foo: str, bar: Dict[str, str]) -> int:
 '''
 
 class T(unittest.TestCase):
+    def test_no_types(self):
+        deployable = parse_function_code(CODE_NO_TYPES, "foobar")
+        types = deployable["types"]
+        self.assertEqual(len(types["params"]), 2)
+        self.assertEqual(types["params"][0], {"name": "a", "type": "Any", "typeSchema": None, "description": ""})
+        self.assertEqual(types["params"][1], {"name": "b", "type": "Any", "typeSchema": None, "description": ""})
+        self.assertEqual(types["returns"]["type"], "Any")
+        self.assertIsNone(types["returns"]["typeSchema"])
+        self.assertEqual(deployable["dependencies"], [])
+
     def test_simple_types(self):
         deployable = parse_function_code(SIMPLE_CODE, "foobar")
         types = deployable["types"]
         self.assertEqual(len(types["params"]), 1)
-        self.assertEqual(types["params"][0], {"name": "n", "type": "int", "description": ""})
+        self.assertEqual(types["params"][0], {"name": "n", "type": "int", "typeSchema": None, "description": ""})
         self.assertEqual(types["returns"]["type"], "int")
         self.assertIsNone(types["returns"]["typeSchema"])
         self.assertEqual(deployable["dependencies"], [])
@@ -137,7 +152,7 @@ class T(unittest.TestCase):
         deployable = parse_function_code(COMPLEX_RETURN_TYPE, "foobar")
         types = deployable["types"]
         self.assertEqual(len(types["params"]), 1)
-        self.assertEqual(types["params"][0], {"name": "n", "type": "int", "description": ""})
+        self.assertEqual(types["params"][0], {"name": "n", "type": "int", "typeSchema": None, "description": ""})
         self.assertEqual(types["returns"]["type"], "Barbar")
         self.assertEqual(types["returns"]["typeSchema"]['title'], "Barbar")
 
@@ -153,7 +168,7 @@ class T(unittest.TestCase):
         deployable = parse_function_code(LIST_COMPLEX_RETURN_TYPE, "foobar")
         types = deployable["types"]
         self.assertEqual(len(types["params"]), 1)
-        self.assertEqual(types["params"][0], {"name": "n", "type": "int", "description": ""})
+        self.assertEqual(types["params"][0], {"name": "n", "type": "int", "typeSchema": None, "description": ""})
         self.assertEqual(types["returns"]["type"], "List[Barbar]")
         self.assertEqual(types["returns"]["typeSchema"]["items"]['title'], "Barbar")
 
@@ -186,11 +201,13 @@ class T(unittest.TestCase):
         self.assertEqual(deployable["types"]["params"][0], {
             "name": "foo",
             "type": "Any",
+            "typeSchema": None,
             "description": "The foo in question"
         })
         self.assertEqual(deployable["types"]["params"][1], {
             "name": "bar",
             "type": "Any",
+            "typeSchema": None,
             "description": "Configuration of bars"
         })
         self.assertEqual(deployable["types"]["returns"], {
@@ -205,11 +222,13 @@ class T(unittest.TestCase):
         self.assertEqual(deployable["types"]["params"][0], {
             "name": "foo",
             "type": "str",
+            "typeSchema": None,
             "description": "The foo in question"
         })
         self.assertEqual(deployable["types"]["params"][1], {
             "name": "bar",
             "type": "Dict[str, str]",
+            "typeSchema": None,
             "description": "Configuration of bars"
         })
         self.assertEqual(deployable["types"]["returns"], {


### PR DESCRIPTION
fixed bug with parsing python functions without any types, and bug where functions with multiple deployment receipts were getting mangled.