### PR TITLE
create mock schemas to fit everything when using no types flag

### DIFF
--- a/polyapi/function_cli.py
+++ b/polyapi/function_cli.py
@@ -86,7 +86,7 @@ def function_add_or_update(
 
     headers = get_auth_headers(api_key)
     resp = requests.post(url, headers=headers, json=data)
-    if resp.status_code == 201:
+    if resp.status_code in [200, 201]:
         print_green("DEPLOYED")
         function_id = resp.json()["id"]
         print(f"Function ID: {function_id}")

--- a/polyapi/utils.py
+++ b/polyapi/utils.py
@@ -97,20 +97,32 @@ def get_type_and_def(
 ) -> Tuple[str, str]:
     """ returns type and type definition for a given PropertyType
     """
+    # Handle cases where type_spec might be None or empty
+    if not type_spec:
+        return "Any", ""
+    
+    # Handle cases where kind might be missing
+    if "kind" not in type_spec:
+        return "Any", ""
+    
     if type_spec["kind"] == "plain":
-        value = type_spec["value"]
+        value = type_spec.get("value", "")
         if value.endswith("[]"):
             primitive = map_primitive_types(value[:-2])
             return f"List[{primitive}]", ""
         else:
             return map_primitive_types(value), ""
     elif type_spec["kind"] == "primitive":
-        return map_primitive_types(type_spec["type"]), ""
+        return map_primitive_types(type_spec.get("type", "any")), ""
     elif type_spec["kind"] == "array":
         if type_spec.get("items"):
             items = type_spec["items"]
             if items.get("$ref"):
-                return wrapped_generate_schema_types(type_spec, "ResponseType", "Dict")  # type: ignore
+                # For no-types mode, avoid complex schema generation
+                try:
+                    return wrapped_generate_schema_types(type_spec, "ResponseType", "Dict")  # type: ignore
+                except:
+                    return "List[Dict]", ""
             else:
                 item_type, _ = get_type_and_def(items)
                 title = f"List[{item_type}]"
@@ -130,13 +142,20 @@ def get_type_and_def(
                 return "List", ""
             elif title:
                 assert isinstance(title, str)
-                return wrapped_generate_schema_types(schema, title, "Dict")  # type: ignore
+                # For no-types mode, avoid complex schema generation
+                try:
+                    return wrapped_generate_schema_types(schema, title, "Dict")  # type: ignore
+                except:
+                    return "Dict", ""
             elif schema.get("allOf") and len(schema["allOf"]):
                 # we are in a case of a single allOf, lets strip off the allOf and move on!
                 # our library doesn't handle allOf well yet
                 allOf = schema["allOf"][0]
                 title = allOf.get("title", allOf.get("name", title_fallback))
-                return wrapped_generate_schema_types(allOf, title, "Dict")
+                try:
+                    return wrapped_generate_schema_types(allOf, title, "Dict")
+                except:
+                    return "Dict", ""
             elif schema.get("items"):
                 # fallback to schema $ref name if no explicit title
                 items = schema.get("items")  # type: ignore
@@ -150,7 +169,10 @@ def get_type_and_def(
                     return "List", ""
 
                 title = f"List[{title}]"
-                return wrapped_generate_schema_types(schema, title, "List")
+                try:
+                    return wrapped_generate_schema_types(schema, title, "List")
+                except:
+                    return "List[Dict]", ""
             elif schema.get("properties"):
                 result = wrapped_generate_schema_types(schema, "ResponseType", "Dict")  # type: ignore
                 return result
@@ -190,9 +212,13 @@ def get_type_and_def(
 
 
 def _maybe_add_fallback_schema_name(a: PropertySpecification):
-    if a["type"]["kind"] == "object" and a["type"].get("schema"):
+    # Handle cases where type might be missing
+    if not a.get("type"):
+        return
+    
+    if a["type"].get("kind") == "object" and a["type"].get("schema"):
         schema = a["type"].get("schema", {})
-        if not schema.get("title") and not schema.get("name") and a["name"]:
+        if not schema.get("title") and not schema.get("name") and a.get("name"):
             schema["title"] = a["name"].title()
 
 
@@ -203,14 +229,23 @@ def parse_arguments(
     arg_string = ""
     for idx, a in enumerate(arguments):
         _maybe_add_fallback_schema_name(a)
-        arg_type, arg_def = get_type_and_def(a["type"])
+        
+        # Handle cases where type might be missing
+        arg_type_spec = a.get("type", {"kind": "any"})
+        arg_type, arg_def = get_type_and_def(arg_type_spec)
         if arg_def:
             args_def.append(arg_def)
-        a["name"] = rewrite_arg_name(a["name"])
+        
+        # Handle cases where name might be missing
+        arg_name = a.get("name", f"arg{idx}")
+        a["name"] = rewrite_arg_name(arg_name)
+        
         arg_string += (
             f"    {a['name']}: {add_type_import_path(function_name, arg_type)}"
         )
-        if not a["required"]:
+        
+        # Handle cases where required might be missing
+        if not a.get("required", True):
             arg_string += " = None"
 
         description = a.get("description", "")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.2", "wheel"]
 
 [project]
 name = "polyapi-python"
-version = "0.3.7.dev2"
+version = "0.3.7.dev3"
 description = "The Python Client for PolyAPI, the IPaaS by Developers for Developers"
 authors = [{ name = "Dan Fellin", email = "dan@polyapi.io" }]
 dependencies = [

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1,5 +1,9 @@
 import unittest
+import os
+import shutil
+import importlib.util
 from polyapi.utils import get_type_and_def, rewrite_reserved
+from polyapi.generate import render_spec, create_empty_schemas_module
 
 OPENAPI_FUNCTION = {
     "kind": "function",
@@ -72,6 +76,28 @@ OPENAPI_FUNCTION = {
     },
 }
 
+# Test spec with missing function data (simulating no_types=true)
+NO_TYPES_SPEC = {
+    "id": "test-id-123",
+    "type": "serverFunction",
+    "context": "test",
+    "name": "testFunction",
+    "description": "A test function for no-types mode",
+    # Note: no "function" field, simulating no_types=true response
+}
+
+# Test spec with minimal function data
+MINIMAL_FUNCTION_SPEC = {
+    "id": "test-id-456",
+    "type": "apiFunction",
+    "context": "test",
+    "name": "minimalFunction",
+    "description": "A minimal function spec",
+    "function": {
+        # Note: no "arguments" or "returnType" fields
+    }
+}
+
 
 class T(unittest.TestCase):
     def test_get_type_and_def(self):
@@ -81,3 +107,183 @@ class T(unittest.TestCase):
     def test_rewrite_reserved(self):
         rv = rewrite_reserved("from")
         self.assertEqual(rv, "_from")
+
+    def test_render_spec_no_function_data(self):
+        """Test that render_spec handles specs with no function data gracefully"""
+        func_str, func_type_defs = render_spec(NO_TYPES_SPEC)
+        
+        # Should generate a function even without function data
+        self.assertIsNotNone(func_str)
+        self.assertIsNotNone(func_type_defs)
+        self.assertIn("testFunction", func_str)
+        self.assertIn("test-id-123", func_str)
+
+    def test_render_spec_minimal_function_data(self):
+        """Test that render_spec handles specs with minimal function data"""
+        func_str, func_type_defs = render_spec(MINIMAL_FUNCTION_SPEC)
+        
+        # Should generate a function with fallback types
+        self.assertIsNotNone(func_str)
+        self.assertIsNotNone(func_type_defs)
+        self.assertIn("minimalFunction", func_str)
+        self.assertIn("test-id-456", func_str)
+        # Should use Any as fallback return type in the type definitions
+        self.assertIn("Any", func_type_defs)
+
+    def test_create_empty_schemas_module(self):
+        """Test that create_empty_schemas_module creates the necessary files"""
+        # Clean up any existing schemas directory
+        schemas_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "polyapi", "schemas")
+        if os.path.exists(schemas_path):
+            shutil.rmtree(schemas_path)
+        
+        # Create empty schemas module
+        create_empty_schemas_module()
+        
+        # Verify the directory and __init__.py file were created
+        self.assertTrue(os.path.exists(schemas_path))
+        init_path = os.path.join(schemas_path, "__init__.py")
+        self.assertTrue(os.path.exists(init_path))
+        
+        # Verify the content of __init__.py includes dynamic schema handling
+        with open(init_path, "r") as f:
+            content = f.read()
+            self.assertIn("Empty schemas module for no-types mode", content)
+            self.assertIn("_GenericSchema", content)
+            self.assertIn("_SchemaModule", content)
+            self.assertIn("__getattr__", content)
+        
+        # Clean up
+        shutil.rmtree(schemas_path)
+
+    def test_no_types_workflow(self):
+        """Test the complete no-types workflow including schema imports and function parsing"""
+        import tempfile
+        import sys
+        from unittest.mock import patch
+        
+        # Clean up any existing schemas directory
+        schemas_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "polyapi", "schemas")
+        if os.path.exists(schemas_path):
+            shutil.rmtree(schemas_path)
+        
+        # Mock get_specs to return empty list (simulating no functions)
+        with patch('polyapi.generate.get_specs', return_value=[]):
+            try:
+                # This should exit with SystemExit due to no functions
+                from polyapi.generate import generate
+                generate(no_types=True)
+            except SystemExit:
+                pass  # Expected when no functions exist
+        
+        # Verify schemas module was created
+        self.assertTrue(os.path.exists(schemas_path))
+        init_path = os.path.join(schemas_path, "__init__.py")
+        self.assertTrue(os.path.exists(init_path))
+        
+        # Test that we can import schemas and use arbitrary schema names
+        from polyapi import schemas
+        
+        # Test various schema access
+        Response = schemas.Response
+        CustomType = schemas.CustomType
+        AnyName = schemas.SomeArbitrarySchemaName
+        
+        # All should return the same generic schema class type
+        self.assertEqual(type(Response).__name__, '_NestedSchemaAccess')
+        self.assertEqual(type(CustomType).__name__, '_NestedSchemaAccess')
+        self.assertEqual(type(AnyName).__name__, '_NestedSchemaAccess')
+        
+        # Test creating instances
+        response_instance = Response()
+        custom_instance = CustomType()
+        
+        self.assertIsInstance(response_instance, dict)
+        self.assertIsInstance(custom_instance, dict)
+        
+        # Test that function code with schema references can be parsed
+        test_code = '''
+from polyapi import polyCustom, schemas
+
+def test_function() -> schemas.Response:
+    polyCustom["executionId"] = "123"
+    return polyCustom
+'''
+        
+        # Create a temporary file with the test code
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.py', delete=False) as f:
+            f.write(test_code)
+            temp_file = f.name
+        
+        try:
+            # Test that the parser can handle this code
+            from polyapi.parser import parse_function_code
+            result = parse_function_code(test_code, 'test_function', 'test_context')
+            
+            self.assertEqual(result['name'], 'test_function')
+            self.assertEqual(result['context'], 'test_context')
+            # Return type should be Any since we're in no-types mode
+            self.assertEqual(result['types']['returns']['type'], 'Any')
+            
+        finally:
+            # Clean up temp file
+            os.unlink(temp_file)
+        
+        # Clean up schemas directory
+        shutil.rmtree(schemas_path)
+
+    def test_nested_schema_access(self):
+        """Test that nested schema access like schemas.random.random2.random3 works"""
+        # Clean up any existing schemas directory
+        schemas_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "polyapi", "schemas")
+        if os.path.exists(schemas_path):
+            shutil.rmtree(schemas_path)
+        
+        # Create empty schemas module
+        create_empty_schemas_module()
+        
+        # Test that we can import and use nested schemas
+        from polyapi import schemas
+        
+        # Test various levels of nesting
+        simple = schemas.Response
+        nested = schemas.random.random2
+        deep_nested = schemas.api.v1.user.profile.data
+        very_deep = schemas.some.very.deep.nested.schema.access
+        
+        # All should be _NestedSchemaAccess instances
+        self.assertEqual(type(simple).__name__, '_NestedSchemaAccess')
+        self.assertEqual(type(nested).__name__, '_NestedSchemaAccess')
+        self.assertEqual(type(deep_nested).__name__, '_NestedSchemaAccess')
+        self.assertEqual(type(very_deep).__name__, '_NestedSchemaAccess')
+        
+        # Test that they can be called and return generic schemas
+        simple_instance = simple()
+        nested_instance = nested()
+        deep_instance = deep_nested()
+        very_deep_instance = very_deep()
+        
+        # All should be dictionaries
+        self.assertIsInstance(simple_instance, dict)
+        self.assertIsInstance(nested_instance, dict)
+        self.assertIsInstance(deep_instance, dict)
+        self.assertIsInstance(very_deep_instance, dict)
+        
+        # Test that function code with nested schemas can be parsed
+        test_code = '''
+from polyapi import polyCustom, schemas
+
+def test_nested_function() -> schemas.api.v1.user.profile:
+    return schemas.api.v1.user.profile()
+'''
+        
+        from polyapi.parser import parse_function_code
+        result = parse_function_code(test_code, 'test_nested_function', 'test_context')
+        
+        self.assertEqual(result['name'], 'test_nested_function')
+        self.assertEqual(result['context'], 'test_context')
+        # Return type should be Any since we're in no-types mode
+        self.assertEqual(result['types']['returns']['type'], 'Any')
+        
+        # Clean up schemas directory
+        shutil.rmtree(schemas_path)


### PR DESCRIPTION
python part of [issue](https://github.com/polyapi/poly-alpha/issues/4009)

- creates a schema file "to fit everything" when --no-types is used to prevent deploy errors
- adds some extra checks