### PR TITLE
EN #4360 fix return types for TS funcs

### DIFF
--- a/polyapi/schema.py
+++ b/polyapi/schema.py
@@ -127,3 +127,7 @@ def clean_title(title: str) -> str:
 def map_primitive_types(type_: str) -> str:
     # Define your mapping logic here
     return JSONSCHEMA_TO_PYTHON_TYPE_MAP.get(type_, "Any")
+
+
+def is_primitive(type_: str) -> bool:
+    return type_ in JSONSCHEMA_TO_PYTHON_TYPE_MAP

--- a/polyapi/utils.py
+++ b/polyapi/utils.py
@@ -11,6 +11,7 @@ from polyapi.schema import (
     wrapped_generate_schema_types,
     clean_title,
     map_primitive_types,
+    is_primitive
 )
 
 
@@ -128,9 +129,15 @@ def get_type_and_def(
                 # TODO fix me
                 # we don't use ReturnType as name for the list type here, we use _ReturnTypeItem
                 return "List", ""
+            elif title and title == "ReturnType" and schema.get("type"):
+                assert isinstance(title, str)
+                schema_type = schema.get("type", "Any")
+                root_type, generated_code = wrapped_generate_schema_types(schema, schema_type, "Dict")  # type: ignore
+                return (map_primitive_types(root_type), "") if is_primitive(root_type) else (root_type, generated_code)  # type: ignore
             elif title:
                 assert isinstance(title, str)
-                return wrapped_generate_schema_types(schema, title, "Dict")  # type: ignore
+                root_type, generated_code = wrapped_generate_schema_types(schema, title, "Dict")  # type: ignore
+                return ("Any", "") if root_type == "ReturnType" else wrapped_generate_schema_types(schema, title, "Dict")  # type: ignore
             elif schema.get("allOf") and len(schema["allOf"]):
                 # we are in a case of a single allOf, lets strip off the allOf and move on!
                 # our library doesn't handle allOf well yet

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.2", "wheel"]
 
 [project]
 name = "polyapi-python"
-version = "0.3.7.dev2"
+version = "0.3.7.dev3"
 description = "The Python Client for PolyAPI, the IPaaS by Developers for Developers"
 authors = [{ name = "Dan Fellin", email = "dan@polyapi.io" }]
 dependencies = [


### PR DESCRIPTION
Fixes py return types for TS funcs.
resolves errors like below and maps to appropriate primitive when possible:
```
  File "/Users/eric.neumann/dev/poly/poly-py-local/.venv/lib/python3.12/site-packages/polyapi/poly/__init__.py", line 11, in <module>
    from . import eric
  File "/Users/eric.neumann/dev/poly/poly-py-local/.venv/lib/python3.12/site-packages/polyapi/poly/eric/__init__.py", line 9, in <module>
    from . import debug
  File "/Users/eric.neumann/dev/poly/poly-py-local/.venv/lib/python3.12/site-packages/polyapi/poly/eric/debug/__init__.py", line 18, in <module>
    ) -> MyServerFunction.ReturnType:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'polyapi.poly.eric.debug.MyServerFunction' has no attribute 'ReturnType'
```

Ref -> https://github.com/polyapi/poly-alpha/issues/4360