### PR TITLE
4523 fix python client to save generate command arguments and reuse them

### DIFF
--- a/polyapi/cli.py
+++ b/polyapi/cli.py
@@ -36,7 +36,7 @@ def execute_from_cli():
             set_api_key_and_url(args.url, args.api_key)
         else:
             initialize_config(force=True)
-            # Setup command should cache "generate everything" behavior (all None/False)
+            # setup command should have default cache values
             from .config import cache_generate_args
             cache_generate_args(contexts=None, names=None, function_ids=None, no_types=False)
             generate()

--- a/polyapi/cli.py
+++ b/polyapi/cli.py
@@ -36,6 +36,9 @@ def execute_from_cli():
             set_api_key_and_url(args.url, args.api_key)
         else:
             initialize_config(force=True)
+            # Setup command should cache "generate everything" behavior (all None/False)
+            from .config import cache_generate_args
+            cache_generate_args(contexts=None, names=None, function_ids=None, no_types=False)
             generate()
 
     setup_parser.set_defaults(command=setup)

--- a/polyapi/cli.py
+++ b/polyapi/cli.py
@@ -46,11 +46,34 @@ def execute_from_cli():
     generate_parser = subparsers.add_parser("generate", help="Generates Poly library")
     generate_parser.add_argument("--no-types", action="store_true", help="Generate SDK without type definitions")
     generate_parser.add_argument("--contexts", type=str, required=False, help="Contexts to generate")
+    generate_parser.add_argument("--names", type=str, required=False, help="Resource names to generate (comma-separated)")
+    generate_parser.add_argument("--function-ids", type=str, required=False, help="Function IDs to generate (comma-separated)")
 
     def generate_command(args):
+        from .config import cache_generate_args, get_cached_generate_args
+        
         initialize_config()
+        
         contexts = args.contexts.split(",") if args.contexts else None
-        generate(contexts=contexts, no_types=args.no_types)
+        names = args.names.split(",") if args.names else None
+        function_ids = args.function_ids.split(",") if args.function_ids else None
+        no_types = args.no_types
+        
+        cached_contexts, cached_names, cached_function_ids, cached_no_types = get_cached_generate_args()
+        
+        final_contexts = contexts if contexts is not None else cached_contexts
+        final_names = names if names is not None else cached_names  
+        final_function_ids = function_ids if function_ids is not None else cached_function_ids
+        final_no_types = no_types if no_types else cached_no_types
+        
+        cache_generate_args(
+            contexts=final_contexts,
+            names=final_names, 
+            function_ids=final_function_ids,
+            no_types=final_no_types
+        )
+        
+        generate(contexts=final_contexts, names=final_names, function_ids=final_function_ids, no_types=final_no_types)
 
     generate_parser.set_defaults(command=generate_command)
 

--- a/polyapi/cli.py
+++ b/polyapi/cli.py
@@ -59,13 +59,78 @@ def execute_from_cli():
         function_ids = args.function_ids.split(",") if args.function_ids else None
         no_types = args.no_types
         
+        # Get cached values to compare restrictiveness
         cached_contexts, cached_names, cached_function_ids, cached_no_types = get_cached_generate_args()
         
-        final_contexts = contexts if contexts is not None else cached_contexts
-        final_names = names if names is not None else cached_names  
-        final_function_ids = function_ids if function_ids is not None else cached_function_ids
-        final_no_types = no_types if no_types else cached_no_types
+        def is_less_restrictive(new_val, cached_val):
+            """Check if new_val is less restrictive than cached_val for list arguments"""
+            if new_val is None:  #no argument = least restrictive
+                return True
+            if cached_val is None:  #cached has no restriction, new has restriction
+                return False
+            return len(new_val) < len(cached_val)  # fewer values = less restrictive 
         
+        def is_no_types_less_restrictive(new_no_types, cached_no_types):
+            """Check if new no_types is less restrictive than cached (false < true)"""
+            if not new_no_types and cached_no_types:
+                return True
+            else:
+                return False  
+        
+        if args.contexts is not None:
+            if cached_contexts is None:
+                final_contexts = contexts  # No cached value, use new
+            else:
+                final_contexts = contexts if is_less_restrictive(contexts, cached_contexts) else cached_contexts
+        else:
+            final_contexts = cached_contexts
+            
+        if args.names is not None:
+            if cached_names is None:
+                final_names = names  # No cached value, use new
+            else:
+                final_names = names if is_less_restrictive(names, cached_names) else cached_names
+        else:
+            final_names = cached_names
+            
+        if args.function_ids is not None:
+            if cached_function_ids is None:
+                final_function_ids = function_ids  # No cached value, use new
+            else:
+                final_function_ids = function_ids if is_less_restrictive(function_ids, cached_function_ids) else cached_function_ids
+        else:
+            final_function_ids = cached_function_ids
+            
+        # For no_types, handle based on whether any args are provided
+        any_args_provided_for_no_types = any([
+            args.contexts is not None,
+            args.names is not None, 
+            args.function_ids is not None,
+            args.no_types
+        ])
+        
+        if args.no_types:  # When --no-types flag is explicitly provided
+            final_no_types = True  # Always use True when explicitly provided
+        elif any_args_provided_for_no_types and not args.no_types:  # When other args provided but no_types is False
+            # False is less restrictive than True, so should replace cached True
+            final_no_types = False if cached_no_types else False
+        else:
+            final_no_types = cached_no_types if cached_no_types is not None else False
+        
+        any_args_provided = any([
+            args.contexts is not None,
+            args.names is not None, 
+            args.function_ids is not None,
+            args.no_types
+        ])
+        
+        if not any_args_provided:
+            final_contexts = None
+            final_names = None
+            final_function_ids = None
+            final_no_types = False
+        
+        # cache the final values used
         cache_generate_args(
             contexts=final_contexts,
             names=final_names, 

--- a/polyapi/config.py
+++ b/polyapi/config.py
@@ -185,18 +185,18 @@ def cache_generate_args(contexts: list | None = None, names: list | None = None,
     # Write values to config
     if contexts is not None:
         config.set("polyapi", "last_generate_contexts_used", ",".join(contexts))
-    else:
-        config.remove_option("polyapi", "last_generate_contexts_used") if config.has_option("polyapi", "last_generate_contexts_used") else None
+    elif config.has_option("polyapi", "last_generate_contexts_used"):
+        config.remove_option("polyapi", "last_generate_contexts_used")
         
     if names is not None:
         config.set("polyapi", "last_generate_names_used", ",".join(names))
-    else:
-        config.remove_option("polyapi", "last_generate_names_used") if config.has_option("polyapi", "last_generate_names_used") else None
+    elif config.has_option("polyapi", "last_generate_names_used"):
+        config.remove_option("polyapi", "last_generate_names_used")
         
     if function_ids is not None:
         config.set("polyapi", "last_generate_function_ids_used", ",".join(function_ids))
-    else:
-        config.remove_option("polyapi", "last_generate_function_ids_used") if config.has_option("polyapi", "last_generate_function_ids_used") else None
+    elif config.has_option("polyapi", "last_generate_function_ids_used"):
+        config.remove_option("polyapi", "last_generate_function_ids_used")
         
     config.set("polyapi", "last_generate_no_types_used", str(no_types).lower())
     

--- a/polyapi/config.py
+++ b/polyapi/config.py
@@ -12,6 +12,10 @@ API_FUNCTION_DIRECT_EXECUTE = None
 MTLS_CERT_PATH = None
 MTLS_KEY_PATH = None
 MTLS_CA_PATH = None
+LAST_GENERATE_CONTEXTS = None
+LAST_GENERATE_NAMES = None
+LAST_GENERATE_FUNCTION_IDS = None
+LAST_GENERATE_NO_TYPES = None
 
 
 def get_config_file_path() -> str:
@@ -55,6 +59,16 @@ def get_api_key_and_url() -> Tuple[str | None, str | None]:
         MTLS_CERT_PATH = config.get("polyapi", "mtls_cert_path", fallback=None)
         MTLS_KEY_PATH = config.get("polyapi", "mtls_key_path", fallback=None)
         MTLS_CA_PATH = config.get("polyapi", "mtls_ca_path", fallback=None)
+        
+        # Read and cache generate command arguments
+        global LAST_GENERATE_CONTEXTS, LAST_GENERATE_NAMES, LAST_GENERATE_FUNCTION_IDS, LAST_GENERATE_NO_TYPES
+        contexts_str = config.get("polyapi", "last_generate_contexts_used", fallback=None)
+        LAST_GENERATE_CONTEXTS = contexts_str.split(",") if contexts_str else None
+        names_str = config.get("polyapi", "last_generate_names_used", fallback=None)
+        LAST_GENERATE_NAMES = names_str.split(",") if names_str else None
+        function_ids_str = config.get("polyapi", "last_generate_function_ids_used", fallback=None)
+        LAST_GENERATE_FUNCTION_IDS = function_ids_str.split(",") if function_ids_str else None
+        LAST_GENERATE_NO_TYPES = config.get("polyapi", "last_generate_no_types_used", fallback="false").lower() == "true"
 
     return key, url
 
@@ -134,3 +148,57 @@ def get_direct_execute_config() -> bool:
         # Force a config read if value isn't cached
         get_api_key_and_url()
     return bool(API_FUNCTION_DIRECT_EXECUTE)
+
+
+def get_cached_generate_args() -> Tuple[list | None, list | None, list | None, bool]:
+    """Return cached generate command arguments"""
+    global LAST_GENERATE_CONTEXTS, LAST_GENERATE_NAMES, LAST_GENERATE_FUNCTION_IDS, LAST_GENERATE_NO_TYPES
+    if LAST_GENERATE_CONTEXTS is None and LAST_GENERATE_NAMES is None and LAST_GENERATE_FUNCTION_IDS is None and LAST_GENERATE_NO_TYPES is None:
+        # Force a config read if values aren't cached
+        get_api_key_and_url()
+    return LAST_GENERATE_CONTEXTS, LAST_GENERATE_NAMES, LAST_GENERATE_FUNCTION_IDS, bool(LAST_GENERATE_NO_TYPES)
+
+
+def cache_generate_args(contexts: list | None = None, names: list | None = None, function_ids: list | None = None, no_types: bool = False):
+    """Cache generate command arguments to config file"""
+    from typing import List
+    
+    # Read existing config
+    path = get_config_file_path()
+    config = configparser.ConfigParser()
+    
+    if os.path.exists(path):
+        with open(path, "r") as f:
+            config.read_file(f)
+    
+    # Ensure polyapi section exists
+    if "polyapi" not in config:
+        config["polyapi"] = {}
+    
+    # Update cached values
+    global LAST_GENERATE_CONTEXTS, LAST_GENERATE_NAMES, LAST_GENERATE_FUNCTION_IDS, LAST_GENERATE_NO_TYPES
+    LAST_GENERATE_CONTEXTS = contexts
+    LAST_GENERATE_NAMES = names
+    LAST_GENERATE_FUNCTION_IDS = function_ids
+    LAST_GENERATE_NO_TYPES = no_types
+    
+    # Write values to config
+    if contexts is not None:
+        config.set("polyapi", "last_generate_contexts_used", ",".join(contexts))
+    else:
+        config.remove_option("polyapi", "last_generate_contexts_used") if config.has_option("polyapi", "last_generate_contexts_used") else None
+        
+    if names is not None:
+        config.set("polyapi", "last_generate_names_used", ",".join(names))
+    else:
+        config.remove_option("polyapi", "last_generate_names_used") if config.has_option("polyapi", "last_generate_names_used") else None
+        
+    if function_ids is not None:
+        config.set("polyapi", "last_generate_function_ids_used", ",".join(function_ids))
+    else:
+        config.remove_option("polyapi", "last_generate_function_ids_used") if config.has_option("polyapi", "last_generate_function_ids_used") else None
+        
+    config.set("polyapi", "last_generate_no_types_used", str(no_types).lower())
+    
+    with open(path, "w") as f:
+        config.write(f)

--- a/polyapi/function_cli.py
+++ b/polyapi/function_cli.py
@@ -1,7 +1,7 @@
 import sys
 from typing import Any, List, Optional
 import requests
-from polyapi.generate import generate as generate_library
+
 from polyapi.config import get_api_key_and_url
 from polyapi.utils import get_auth_headers, print_green, print_red, print_yellow
 from polyapi.parser import parse_function_code, get_jsonschema_type

--- a/polyapi/function_cli.py
+++ b/polyapi/function_cli.py
@@ -91,7 +91,10 @@ def function_add_or_update(
         function_id = resp.json()["id"]
         print(f"Function ID: {function_id}")
         if generate:
-            generate_library()
+            # Use cached generate arguments when regenerating after function deployment
+            from polyapi.config import get_cached_generate_args
+            cached_contexts, cached_names, cached_function_ids, cached_no_types = get_cached_generate_args()
+            generate_library(contexts=cached_contexts, names=cached_names, function_ids=cached_function_ids, no_types=cached_no_types)
     else:
         print("Error adding function.")
         print(resp.status_code)

--- a/polyapi/function_cli.py
+++ b/polyapi/function_cli.py
@@ -92,9 +92,8 @@ def function_add_or_update(
         print(f"Function ID: {function_id}")
         if generate:
             # Use cached generate arguments when regenerating after function deployment
-            from polyapi.config import get_cached_generate_args
-            cached_contexts, cached_names, cached_function_ids, cached_no_types = get_cached_generate_args()
-            generate_library(contexts=cached_contexts, names=cached_names, function_ids=cached_function_ids, no_types=cached_no_types)
+            from polyapi.generate import generate_from_cache
+            generate_from_cache()
     else:
         print("Error adding function.")
         print(resp.status_code)

--- a/polyapi/generate.py
+++ b/polyapi/generate.py
@@ -285,7 +285,8 @@ def generate_from_cache() -> None:
 
 
 def generate(contexts: Optional[List[str]] = None, names: Optional[List[str]] = None, function_ids: Optional[List[str]] = None, no_types: bool = False) -> None:
-    
+    generate_msg = f"Generating Poly Python SDK for contexts ${contexts}..." if contexts else "Generating Poly Python SDK..."
+    print(generate_msg, end="", flush=True)
     remove_old_library()
 
     specs = get_specs(contexts=contexts, names=names, function_ids=function_ids, no_types=no_types)

--- a/polyapi/generate.py
+++ b/polyapi/generate.py
@@ -14,7 +14,7 @@ from .api import render_api_function
 from .server import render_server_function
 from .utils import add_import_to_init, get_auth_headers, init_the_init, print_green, to_func_namespace
 from .variables import generate_variables
-from .config import get_api_key_and_url, get_direct_execute_config
+from .config import get_api_key_and_url, get_direct_execute_config, get_cached_generate_args
 
 SUPPORTED_FUNCTION_TYPES = {
     "apiFunction",
@@ -268,6 +268,21 @@ class _NestedSchemaAccess:
 import sys
 sys.modules[__name__] = _SchemaModule()
 ''')
+
+
+def generate_from_cache() -> None:
+    """
+    Generate using cached values. This is used when generate is called programmatically
+    (e.g., after deploying a function) rather than explicitly by the user.
+    """
+    cached_contexts, cached_names, cached_function_ids, cached_no_types = get_cached_generate_args()
+    
+    generate(
+        contexts=cached_contexts, 
+        names=cached_names, 
+        function_ids=cached_function_ids, 
+        no_types=cached_no_types
+    )
 
 
 def generate(contexts: Optional[List[str]] = None, names: Optional[List[str]] = None, function_ids: Optional[List[str]] = None, no_types: bool = False) -> None:

--- a/polyapi/generate.py
+++ b/polyapi/generate.py
@@ -36,7 +36,7 @@ Unresolved schema, please add the following schema to complete it:
   path:'''
 
 
-def get_specs(contexts=Optional[List[str]], no_types: bool = False) -> List:
+def get_specs(contexts: Optional[List[str]] = None, names: Optional[List[str]] = None, function_ids: Optional[List[str]] = None, no_types: bool = False) -> List:
     api_key, api_url = get_api_key_and_url()
     assert api_key
     headers = get_auth_headers(api_key)
@@ -45,6 +45,12 @@ def get_specs(contexts=Optional[List[str]], no_types: bool = False) -> List:
 
     if contexts:
         params["contexts"] = contexts
+    
+    if names:
+        params["names"] = names
+        
+    if function_ids:
+        params["functionIds"] = function_ids
 
     # Add apiFunctionDirectExecute parameter if direct execute is enabled
     if get_direct_execute_config():
@@ -264,12 +270,11 @@ sys.modules[__name__] = _SchemaModule()
 ''')
 
 
-def generate(contexts: Optional[List[str]] = None, no_types: bool = False) -> None:
-    generate_msg = f"Generating Poly Python SDK for contexts ${contexts}..." if contexts else "Generating Poly Python SDK..."
-    print(generate_msg, end="", flush=True)
+def generate(contexts: Optional[List[str]] = None, names: Optional[List[str]] = None, function_ids: Optional[List[str]] = None, no_types: bool = False) -> None:
+    
     remove_old_library()
 
-    specs = get_specs(no_types=no_types, contexts=contexts)
+    specs = get_specs(contexts=contexts, names=names, function_ids=function_ids, no_types=no_types)
     cache_specs(specs)
 
     limit_ids: List[str] = []  # useful for narrowing down generation to a single function to debug

--- a/polyapi/generate.py
+++ b/polyapi/generate.py
@@ -272,8 +272,7 @@ sys.modules[__name__] = _SchemaModule()
 
 def generate_from_cache() -> None:
     """
-    Generate using cached values. This is used when generate is called programmatically
-    (e.g., after deploying a function) rather than explicitly by the user.
+    Generate using cached values after non-explicit call.
     """
     cached_contexts, cached_names, cached_function_ids, cached_no_types = get_cached_generate_args()
     

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,14 +3,14 @@ requires = ["setuptools>=61.2", "wheel"]
 
 [project]
 name = "polyapi-python"
-version = "0.3.8.dev0"
+version = "0.3.8.dev2"
 description = "The Python Client for PolyAPI, the IPaaS by Developers for Developers"
 authors = [{ name = "Dan Fellin", email = "dan@polyapi.io" }]
 dependencies = [
     "requests>=2.32.3",
     "typing_extensions>=4.12.2",
     "jsonschema-gentypes==2.6.0",
-    "pydantic==2.6.4",
+    "pydantic>=2.6.4",
     "stdlib_list==0.10.0",
     "colorama==0.4.4",
     "python-socketio[asyncio_client]==5.11.1",


### PR DESCRIPTION
Should cache arguments and only rewrite them when there are less restrictive args.
function id and names weren't arguments, I think, so I added those as arguments to generate. 