### PR TITLE
running into weird ord bug in python3.11, lets do simpler 7 char hash

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
-ignore = E203,E303,E402,E501,E722,W391,F401,W292,F811
+ignore = E203,E303,E402,E501,E722,W391,F401,W292,F811,E302
 max-line-length = 150
 max-complexity = 22

--- a/polyapi/deployables.py
+++ b/polyapi/deployables.py
@@ -1,4 +1,6 @@
 import os
+import string
+import random
 import subprocess
 import json
 import hashlib
@@ -76,9 +78,10 @@ class SyncDeployment(TypedDict, total=False):
     id: Optional[str]
     deployed: Optional[str]
 
+
 DeployableTypeEntries: List[Tuple[DeployableTypeNames, DeployableTypes]] = [
-    ("PolyServerFunction", "server-function"), # type: ignore
-    ("PolyClientFunction", "client-function"), # type: ignore
+    ("PolyServerFunction", "server-function"),  # type: ignore
+    ("PolyClientFunction", "client-function"),  # type: ignore
 ]
 
 DeployableTypeToName: Dict[DeployableTypeNames, DeployableTypes] = {name: type for name, type in DeployableTypeEntries}
@@ -175,7 +178,7 @@ def get_git_revision(branch_or_tag: str = "HEAD") -> str:
         return check_output(["git", "rev-parse", "--short", branch_or_tag], text=True).strip()
     except CalledProcessError:
         # Return a random 7-character hash as a fallback
-        return "".join(format(ord(str(c)), 'x') for c in os.urandom(4))[:7]
+        return "".join([random.choice(string.ascii_letters + string.digits) for _ in range(7)])
 
 def get_cache_deployments_revision() -> str:
     """Retrieve the cache deployments revision from a file."""

--- a/polyapi/sync.py
+++ b/polyapi/sync.py
@@ -24,7 +24,7 @@ def read_file(file_path: str) -> str:
         return file.read()
 
 def group_by(items: List[Dict], key: str) -> Dict[str, List[Dict]]:
-    grouped = {}
+    grouped = {}  # type: ignore
     for item in items:
         grouped.setdefault(item[key], []).append(item)
     return grouped
@@ -32,7 +32,7 @@ def group_by(items: List[Dict], key: str) -> Dict[str, List[Dict]]:
 def remove_deployable_function(deployable: SyncDeployment) -> bool:
     api_key, _ = get_api_key_and_url()
     if not api_key:
-        raise Error("Missing api key!")
+        raise Exception("Missing api key!")
     headers = get_auth_headers(api_key)
     url = f'{deployable["instance"]}/functions/{deployable["type"].replace("-function", "")}/{deployable["id"]}'
     response = requests.get(url, headers=headers)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.2", "wheel"]
 
 [project]
 name = "polyapi-python"
-version = "0.3.9.dev13"
+version = "0.3.9.dev14"
 description = "The Python Client for PolyAPI, the IPaaS by Developers for Developers"
 authors = [{ name = "Dan Fellin", email = "dan@polyapi.io" }]
 dependencies = [


### PR DESCRIPTION
switch to a much simpler, "classic" random 7 character hash choice in python

outside of a git repo, python sync throwing this strange bug:

```
phoenix:~/poly/py-test/dev dev $ python -m polyapi sync
fatal: not a git repository (or any of the parent directories): .git
Traceback (most recent call last):
  File "/home/daniel/poly/py-test/dev/.venv/lib/python3.11/site-packages/polyapi/deployables.py", line 175, in get_git_revision
    return check_output(["git", "rev-parse", "--short", branch_or_tag], text=True).strip()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/subprocess.py", line 466, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/subprocess.py", line 571, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['git', 'rev-parse', '--short', 'HEAD']' returned non-zero exit status 128.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/daniel/poly/py-test/dev/.venv/lib/python3.11/site-packages/polyapi/__main__.py", line 5, in <module>
    execute_from_cli()
  File "/home/daniel/poly/py-test/dev/.venv/lib/python3.11/site-packages/polyapi/cli.py", line 233, in execute_from_cli
    parsed_args.command(parsed_args)
  File "/home/daniel/poly/py-test/dev/.venv/lib/python3.11/site-packages/polyapi/cli.py", line 213, in sync
    prepare_deployables(lazy=True, disable_docs=True, disable_ai=True)
  File "/home/daniel/poly/py-test/dev/.venv/lib/python3.11/site-packages/polyapi/prepare.py", line 119, in prepare_deployables
    if lazy and is_cache_up_to_date():
                ^^^^^^^^^^^^^^^^^^^^^
  File "/home/daniel/poly/py-test/dev/.venv/lib/python3.11/site-packages/polyapi/deployables.py", line 205, in is_cache_up_to_date
    git_revision = get_git_revision()  # This function needs to be defined or imported
                   ^^^^^^^^^^^^^^^^^^
  File "/home/daniel/poly/py-test/dev/.venv/lib/python3.11/site-packages/polyapi/deployables.py", line 178, in get_git_revision
    return "".join(format(ord(str(c)), 'x') for c in os.urandom(4))[:7]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/daniel/poly/py-test/dev/.venv/lib/python3.11/site-packages/polyapi/deployables.py", line 178, in <genexpr>
    return "".join(format(ord(str(c)), 'x') for c in os.urandom(4))[:7]
                          ^^^^^^^^^^^
TypeError: ord() expected a character, but string of length 3 found
```