### PR TITLE
5933 fixing loopy imports

### DIFF
--- a/polyapi/client.py
+++ b/polyapi/client.py
@@ -41,14 +41,32 @@ _TYPING_SUBSCRIPT_NAMES = frozenset({
 _TYPING_FUNCTIONAL_NAMES = frozenset({
     'TypedDict', 'NamedTuple', 'NewType',
     'TypeVar', 'ParamSpec', 'TypeVarTuple',
-    'TypeAliasType',
+    'TypeAliasType', 'ForwardRef',
 })
+
+_TYPING_MODULES = frozenset({'typing', 'typing_extensions'})
 
 # Names that are unambiguously types when they appear as leaves in X | Y expressions.
 # This anchors the union heuristic so that flag constants (READ | WRITE) are rejected.
 _BUILTIN_TYPE_NAMES = frozenset({
-    'str', 'int', 'float', 'bool', 'bytes', 'complex', 'object', 'bytearray',
+    'str', 'int', 'float', 'bool', 'bytes', 'complex', 'object', 'bytearray', 'None',
 }) | _TYPING_SUBSCRIPT_NAMES
+
+
+def _collect_free_names(table: symtable_mod.SymbolTable) -> set[str]:
+    """Recursively collect all module-scope-referenced names from a symtable tree.
+
+    A flat get_symbols() only sees the direct class body. Nested classes (Inner
+    inside Outer) have their own child tables — their free/global references would
+    be missed without this recursive walk.
+    """
+    names: set[str] = set()
+    for sym in table.get_symbols():
+        if sym.is_free() or (sym.is_global() and sym.is_referenced()):
+            names.add(sym.get_name())
+    for child in table.get_children():
+        names.update(_collect_free_names(child))
+    return names
 
 
 def _import_bound_names(node: ast.stmt) -> set:
@@ -75,22 +93,34 @@ def _is_safe_import(node: ast.stmt) -> bool:
 
 
 def _is_type_union_leaf(node: ast.expr) -> bool:
-    """Return True if node is a valid leaf in latest type union op (X | Y | None).
+    """Return True if node is a valid leaf in a new-style type union (X | Y | None).
 
-    Rejects non-type leaves like integer/string constants so that bitwise OR
-    expressions (FLAGS = 1 | 2) are not misidentified as type aliases.
+    Every leaf must be an unambiguous type — we reject anything that could
+    plausibly be a runtime value (flag constant, arbitrary subscript, etc.).
     """
     if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
         return _is_type_union_leaf(node.left) and _is_type_union_leaf(node.right)
+    # Name: only known typing / builtin type names (rejects READ, WRITE, etc.)
     if isinstance(node, ast.Name):
-        return True  # str, int, MyClass, None (as a name), ...
+        return node.id in _BUILTIN_TYPE_NAMES
+    # Attribute: only from typing / typing_extensions (rejects os.O_RDONLY, etc.)
     if isinstance(node, ast.Attribute):
-        return True  # typing.Optional, module.MyClass, ...
+        return isinstance(node.value, ast.Name) and node.value.id in _TYPING_MODULES
+    # Subscript: head must itself be a known typing name (rejects my_list[0], etc.)
     if isinstance(node, ast.Subscript):
-        return True  # Optional[int], List[str], ...
+        val = node.value
+        if isinstance(val, ast.Name):
+            return val.id in _TYPING_SUBSCRIPT_NAMES
+        if isinstance(val, ast.Attribute):
+            return (
+                isinstance(val.value, ast.Name)
+                and val.value.id in _TYPING_MODULES
+                and val.attr in _TYPING_SUBSCRIPT_NAMES
+            )
+        return False
     if isinstance(node, ast.Constant) and node.value is None:
-        return True  # literal None in  X | None
-    return False     # int/str/bytes/... constants → bitwise OR, not a union
+        return True  # None in X | None
+    return False
 
 
 def _union_has_type_anchor(node: ast.expr) -> bool:
@@ -126,9 +156,14 @@ def _rhs_is_type_construct(node: ast.expr) -> bool:
         if isinstance(val, ast.Name):
             return val.id in _TYPING_SUBSCRIPT_NAMES
         if isinstance(val, ast.Attribute):
-            return val.attr in _TYPING_SUBSCRIPT_NAMES
-    # X = str | int | None — new-style union; validate leaves to reject FLAGS = 1 | 2
-    # Also require a type anchor so named flag constants (READ | WRITE) are rejected.
+            return (
+                isinstance(val.value, ast.Name)
+                and val.value.id in _TYPING_MODULES
+                and val.attr in _TYPING_SUBSCRIPT_NAMES
+            )
+    # X = str | int | None — new-style union.
+    # _is_type_union_leaf validates every leaf strictly, so FLAGS = 1 | 2 and
+    # READ | WRITE are both rejected without a separate anchor check.
     if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
         return _is_type_union_leaf(node) and _union_has_type_anchor(node)
     # X = TypedDict("X", {...}), T = TypeVar("T"), P = ParamSpec("P"), ...
@@ -138,7 +173,11 @@ def _rhs_is_type_construct(node: ast.expr) -> bool:
         if isinstance(func, ast.Name):
             return func.id in _TYPING_FUNCTIONAL_NAMES
         if isinstance(func, ast.Attribute):
-            return func.attr in _TYPING_FUNCTIONAL_NAMES
+            return (
+                isinstance(func.value, ast.Name)
+                and func.value.id in _TYPING_MODULES
+                and func.attr in _TYPING_FUNCTIONAL_NAMES
+            )
     return False
 
 
@@ -151,6 +190,8 @@ def _extract_type_definitions(code: str) -> Tuple[str, str, str]:
     Returns:
         (type_imports_code, type_defs_code, runtime_code)
     """
+    code = code.replace('\r\n', '\n').replace('\r', '\n')
+
     try:
         tree = ast.parse(code)
         st = symtable_mod.symtable(code, '<client_fn>', 'exec')
@@ -209,14 +250,13 @@ def _extract_type_definitions(code: str) -> Tuple[str, str, str]:
     queue = list(class_names)
     while queue:
         name = queue.pop()
-        # deps from class body via symtable
+        # deps from class body via symtable — recursive so nested classes
+        # (Inner inside Outer) contribute their free/global refs too
         if name in child_tables:
-            for sym in child_tables[name].get_symbols():
-                if sym.is_free() or (sym.is_global() and sym.is_referenced()):
-                    dep = sym.get_name()
-                    if dep in module_level_symbols and dep not in module_scope_names:
-                        module_scope_names.add(dep)
-                        queue.append(dep)
+            for dep in _collect_free_names(child_tables[name]):
+                if dep in module_level_symbols and dep not in module_scope_names:
+                    module_scope_names.add(dep)
+                    queue.append(dep)
         # deps from base classes and decorators (not visible in class body symtable)
         for dep in class_outer_deps.get(name, set()):
             if dep in module_level_symbols and dep not in module_scope_names:
@@ -252,10 +292,13 @@ def _extract_type_definitions(code: str) -> Tuple[str, str, str]:
         elif hasattr(ast, 'TypeAlias') and isinstance(node, ast.TypeAlias):
             is_type_def = True
 
-        # Assignments: check if target is in our module_scope_names set
-        elif isinstance(node, ast.Assign) and len(node.targets) == 1:
-            if isinstance(node.targets[0], ast.Name):
-                is_type_def = node.targets[0].id in module_scope_names
+        # Assignments: check if any target is in our module_scope_names set.
+        # Handles both single (X = ...) and chained (X = Y = ...) assignments.
+        elif isinstance(node, ast.Assign):
+            is_type_def = any(
+                isinstance(t, ast.Name) and t.id in module_scope_names
+                for t in node.targets
+            )
 
         # Annotated assignments with value
         elif isinstance(node, ast.AnnAssign) and node.value is not None:
@@ -280,7 +323,13 @@ def _extract_type_definitions(code: str) -> Tuple[str, str, str]:
             for i in range(start, end):
                 type_def_lines.add(i)
 
-        prev_was_type_def = is_type_def or is_type_import
+        # Expr nodes (bare strings) don't propagate the chain — only real
+        # type defs / imports do. This prevents consecutive bare strings after
+        # a class from all being hoisted.
+        if isinstance(node, ast.Expr):
+            prev_was_type_def = False
+        else:
+            prev_was_type_def = is_type_def or is_type_import
 
     # Phase 5: Also promote assignments that LOOK like type aliases
     # even if no class references them yet.
@@ -289,15 +338,18 @@ def _extract_type_definitions(code: str) -> Tuple[str, str, str]:
     # so this is the ONE remaining heuristic — but scoped narrowly to
     # assignments whose RHS is a typing construct (Subscript/BinOp with |)
     for node in ast.iter_child_nodes(tree):
-        if isinstance(node, ast.Assign) and len(node.targets) == 1:
-            target = node.targets[0]
-            if isinstance(target, ast.Name) and target.id not in module_scope_names:
-                if _rhs_is_type_construct(node.value):
-                    start = node.lineno - 1
-                    end = getattr(node, 'end_lineno', None) or start + 1
-                    for i in range(start, end):
-                        type_def_lines.add(i)
-                    module_scope_names.add(target.id)
+        if not isinstance(node, ast.Assign):
+            continue
+        new_names = [
+            t.id for t in node.targets
+            if isinstance(t, ast.Name) and t.id not in module_scope_names
+        ]
+        if new_names and _rhs_is_type_construct(node.value):
+            start = node.lineno - 1
+            end = getattr(node, 'end_lineno', None) or start + 1
+            for i in range(start, end):
+                type_def_lines.add(i)
+            module_scope_names.update(new_names)
 
     # Build output
     imports_out: list[str] = []

--- a/polyapi/client.py
+++ b/polyapi/client.py
@@ -44,6 +44,12 @@ _TYPING_FUNCTIONAL_NAMES = frozenset({
     'TypeAliasType',
 })
 
+# Names that are unambiguously types when they appear as leaves in X | Y expressions.
+# This anchors the union heuristic so that flag constants (READ | WRITE) are rejected.
+_BUILTIN_TYPE_NAMES = frozenset({
+    'str', 'int', 'float', 'bool', 'bytes', 'complex', 'object', 'bytearray',
+}) | _TYPING_SUBSCRIPT_NAMES
+
 
 def _import_bound_names(node: ast.stmt) -> set:
     """Names bound in the local namespace by an import statement."""
@@ -87,6 +93,24 @@ def _is_type_union_leaf(node: ast.expr) -> bool:
     return False     # int/str/bytes/... constants → bitwise OR, not a union
 
 
+def _union_has_type_anchor(node: ast.expr) -> bool:
+    """Return True if the BinOr tree contains at least one vague type leaf.
+
+    Prevents named flag constants (READ | WRITE) from being misidentified as type
+    unions. A 'type anchor' is a leaf that could never plausibly be a flag value:
+    a known primitive/typing name, a None constant, or a subscript expression.
+    """
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
+        return _union_has_type_anchor(node.left) or _union_has_type_anchor(node.right)
+    if isinstance(node, ast.Constant) and node.value is None:
+        return True
+    if isinstance(node, ast.Name):
+        return node.id in _BUILTIN_TYPE_NAMES
+    if isinstance(node, ast.Subscript):
+        return True
+    return False
+
+
 def _rhs_is_type_construct(node: ast.expr) -> bool:
     """Check if an assignment RHS is a typing construct.
 
@@ -104,8 +128,9 @@ def _rhs_is_type_construct(node: ast.expr) -> bool:
         if isinstance(val, ast.Attribute):
             return val.attr in _TYPING_SUBSCRIPT_NAMES
     # X = str | int | None — new-style union; validate leaves to reject FLAGS = 1 | 2
+    # Also require a type anchor so named flag constants (READ | WRITE) are rejected.
     if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
-        return _is_type_union_leaf(node)
+        return _is_type_union_leaf(node) and _union_has_type_anchor(node)
     # X = TypedDict("X", {...}), T = TypeVar("T"), P = ParamSpec("P"), ...
     # Also handles typing.TypedDict(...) where node.func is ast.Attribute
     if isinstance(node, ast.Call):

--- a/polyapi/client.py
+++ b/polyapi/client.py
@@ -417,9 +417,17 @@ def _extract_type_definitions(code: str) -> Tuple[str, str, str]:
                     dyn_queue.append(cls_name)
         module_scope_names -= dyn_remove
 
-    # Names available at module scope: builtins, typing module names, and anything
-    # that survived the Phase 3b/3c prune. Used to guard Phase 4 assignment hoisting.
-    module_scope_available = _BUILTIN_TYPE_NAMES | _TYPING_MODULES | module_scope_names
+    # Names available at module scope: builtins, typing module names, anything that
+    # survived Phase 3b/3c, and names bound by safe imports (hoisted by Phase 4).
+    # Used to guard Phase 4 assignment hoisting — if a RHS name isn't in this set
+    # it won't be defined when the hoisted assignment runs.
+    safe_import_bound: set[str] = set()
+    for _node in ast.iter_child_nodes(tree):
+        if isinstance(_node, (ast.Import, ast.ImportFrom)) and _is_safe_import(_node):
+            safe_import_bound.update(_import_bound_names(_node))
+    module_scope_available = (
+        _BUILTIN_TYPE_NAMES | _TYPING_MODULES | module_scope_names | safe_import_bound
+    )
 
     # Phase 4: Classify each AST node using the symtable results
     type_import_lines: set[int] = set()

--- a/polyapi/client.py
+++ b/polyapi/client.py
@@ -265,7 +265,8 @@ def _wrap_code_in_try_except(function_name: str, code: str) -> Tuple[str, str]:
         f"'{function_name}', function unavailable: \" + str(e))"
     )
 
-    indented = '\n    '.join(runtime_code.split('\n'))
+    body = runtime_code if runtime_code.strip() else 'pass'
+    indented = '\n    '.join(body.split('\n'))
     wrapped = prefix + indented + suffix
 
     return module_scope, wrapped

--- a/polyapi/client.py
+++ b/polyapi/client.py
@@ -417,6 +417,10 @@ def _extract_type_definitions(code: str) -> Tuple[str, str, str]:
                     dyn_queue.append(cls_name)
         module_scope_names -= dyn_remove
 
+    # Names available at module scope: builtins, typing module names, and anything
+    # that survived the Phase 3b/3c prune. Used to guard Phase 4 assignment hoisting.
+    module_scope_available = _BUILTIN_TYPE_NAMES | _TYPING_MODULES | module_scope_names
+
     # Phase 4: Classify each AST node using the symtable results
     type_import_lines: set[int] = set()
     type_def_lines: set[int] = set()
@@ -449,18 +453,32 @@ def _extract_type_definitions(code: str) -> Tuple[str, str, str]:
                 and node.name.id in module_scope_names
             )
 
-        # Assignments: check if any target is in our module_scope_names set.
-        # Handles both single (X = ...) and chained (X = Y = ...) assignments.
+        # Assignments: check if any target is in our module_scope_names set,
+        # AND that all RHS names are available at module scope. The Phase 3b
+        # cascade only follows class symtable deps — a non-class alias like
+        # STATUS = SomeType can land in module_scope_names via BFS without
+        # SomeType being checked, causing a NameError when hoisted.
         elif isinstance(node, ast.Assign):
-            is_type_def = any(
+            target_in_scope = any(
                 isinstance(t, ast.Name) and t.id in module_scope_names
                 for t in node.targets
             )
+            rhs_names_available = all(
+                n.id in module_scope_available
+                for n in ast.walk(node.value)
+                if isinstance(n, ast.Name)
+            )
+            is_type_def = target_in_scope and rhs_names_available
 
         # Annotated assignments with value
         elif isinstance(node, ast.AnnAssign) and node.value is not None:
             if isinstance(node.target, ast.Name):
-                is_type_def = node.target.id in module_scope_names
+                rhs_names_available = all(
+                    n.id in module_scope_available
+                    for n in ast.walk(node.value)
+                    if isinstance(n, ast.Name)
+                )
+                is_type_def = node.target.id in module_scope_names and rhs_names_available
 
         # Function definitions: NEVER module scope (these are runtime)
         elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):

--- a/polyapi/client.py
+++ b/polyapi/client.py
@@ -105,9 +105,12 @@ def _extract_type_definitions(code: str) -> Tuple[str, str, str]:
     # must also be at module scope
     module_scope_names: set[str] = set(class_names)
 
-    # Get all module-level assigned symbol names for reference (imports count as assigned)
+    # Get all module-level defined symbol names for reference.
+    # is_assigned() covers normal assignments; is_imported() covers import statements
+    # (symtable tracks these separately via DEF_IMPORT vs DEF_LOCAL flags).
     module_level_symbols: set[str] = {
-        sym.get_name() for sym in st.get_symbols() if sym.is_assigned()
+        sym.get_name() for sym in st.get_symbols()
+        if sym.is_assigned() or sym.is_imported()
     }
 
     # AST-level deps from base classes and decorators: symtable misses these

--- a/polyapi/client.py
+++ b/polyapi/client.py
@@ -13,11 +13,35 @@ from typing import List, Dict, Any, TypedDict
 """
 
 _TYPING_SUBSCRIPT_NAMES = frozenset({
-    'Literal', 'Dict', 'List', 'Set', 'FrozenSet', 'Tuple', 'Type',
-    'Optional', 'Union', 'ClassVar', 'Final', 'Annotated', 'Required',
-    'NotRequired', 'ReadOnly',
-    # lowercase generics (3.9+)
+    # Special forms
+    'ClassVar', 'Final', 'Annotated', 'Required', 'NotRequired', 'ReadOnly',
+    'Optional', 'Union', 'Literal', 'Type',
+    'Concatenate', 'Unpack', 'TypeGuard', 'TypeIs',
+    # Standalone-but-subscriptable specials
+    'LiteralString', 'Self', 'Never', 'NoReturn',
+    # Generic ABCs (collections.abc / contextlib)
+    'Callable', 'Awaitable', 'Coroutine',
+    'AsyncIterable', 'AsyncIterator', 'AsyncGenerator', 'AsyncContextManager',
+    'Iterable', 'Iterator', 'Generator', 'ContextManager',
+    'Container', 'Collection', 'Reversible', 'Sized', 'Hashable',
+    'Mapping', 'MutableMapping', 'MappingView', 'KeysView', 'ItemsView', 'ValuesView',
+    'Sequence', 'MutableSequence', 'MutableSet', 'AbstractSet',
+    'IO', 'BinaryIO', 'TextIO', 'Match', 'Pattern',
+    # Concrete generic aliases
+    'Dict', 'List', 'Set', 'FrozenSet', 'Tuple',
+    'DefaultDict', 'OrderedDict', 'Counter', 'Deque', 'ChainMap',
+    # Base classes used with subscript (Generic[T], Protocol[T])
+    'Generic', 'Protocol',
+    # AnyStr is a TypeVar but appears in subscript position
+    'AnyStr',
+    # lowercase builtins (3.9+)
     'dict', 'list', 'set', 'frozenset', 'tuple', 'type',
+})
+
+_TYPING_FUNCTIONAL_NAMES = frozenset({
+    'TypedDict', 'NamedTuple', 'NewType',
+    'TypeVar', 'ParamSpec', 'TypeVarTuple',
+    'TypeAliasType',
 })
 
 
@@ -44,6 +68,25 @@ def _is_safe_import(node: ast.stmt) -> bool:
     return False
 
 
+def _is_type_union_leaf(node: ast.expr) -> bool:
+    """Return True if node is a valid leaf in latest type union op (X | Y | None).
+
+    Rejects non-type leaves like integer/string constants so that bitwise OR
+    expressions (FLAGS = 1 | 2) are not misidentified as type aliases.
+    """
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
+        return _is_type_union_leaf(node.left) and _is_type_union_leaf(node.right)
+    if isinstance(node, ast.Name):
+        return True  # str, int, MyClass, None (as a name), ...
+    if isinstance(node, ast.Attribute):
+        return True  # typing.Optional, module.MyClass, ...
+    if isinstance(node, ast.Subscript):
+        return True  # Optional[int], List[str], ...
+    if isinstance(node, ast.Constant) and node.value is None:
+        return True  # literal None in  X | None
+    return False     # int/str/bytes/... constants → bitwise OR, not a union
+
+
 def _rhs_is_type_construct(node: ast.expr) -> bool:
     """Check if an assignment RHS is a typing construct.
 
@@ -53,15 +96,24 @@ def _rhs_is_type_construct(node: ast.expr) -> bool:
     We check the VALUE, not the name — much more reliable than naming conventions.
     """
     # X = Literal[...], X = Dict[str, Any], X = list[Foo], X = Union[...]
-    if isinstance(node, ast.Subscript) and isinstance(node.value, ast.Name):
-        return node.value.id in _TYPING_SUBSCRIPT_NAMES
-    # X = str | int | float new Union
+    # Also handles typing.Optional[int] where node.value is ast.Attribute
+    if isinstance(node, ast.Subscript):
+        val = node.value
+        if isinstance(val, ast.Name):
+            return val.id in _TYPING_SUBSCRIPT_NAMES
+        if isinstance(val, ast.Attribute):
+            return val.attr in _TYPING_SUBSCRIPT_NAMES
+    # X = str | int | None — new-style union; validate leaves to reject FLAGS = 1 | 2
     if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
-        return True
-    # X = TypedDict("X", {...}) — functional form
-    if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
-        if node.func.id in ('TypedDict', 'NamedTuple', 'NewType'):
-            return True
+        return _is_type_union_leaf(node)
+    # X = TypedDict("X", {...}), T = TypeVar("T"), P = ParamSpec("P"), ...
+    # Also handles typing.TypedDict(...) where node.func is ast.Attribute
+    if isinstance(node, ast.Call):
+        func = node.func
+        if isinstance(func, ast.Name):
+            return func.id in _TYPING_FUNCTIONAL_NAMES
+        if isinstance(func, ast.Attribute):
+            return func.attr in _TYPING_FUNCTIONAL_NAMES
     return False
 
 

--- a/polyapi/client.py
+++ b/polyapi/client.py
@@ -1,4 +1,6 @@
 import ast
+import copy
+import re
 import symtable as symtable_mod
 from typing import Any, Dict, List, Tuple
 
@@ -141,6 +143,29 @@ def _union_has_type_anchor(node: ast.expr) -> bool:
     return False
 
 
+def _collect_local_shadows(tree: ast.Module) -> frozenset[str]:
+    """Typing-set names that are redefined at module scope (assignments or defs).
+
+    If `List = get_runtime_list()` or `def TypeVar(...):` appears in the file,
+    those names must not be trusted as typing constructs in Phase 5 even though
+    they appear in the static whitelist.
+    """
+    all_typing = _TYPING_SUBSCRIPT_NAMES | _TYPING_FUNCTIONAL_NAMES
+    shadowed: set[str] = set()
+    for node in ast.iter_child_nodes(tree):
+        if isinstance(node, ast.Assign):
+            for t in node.targets:
+                if isinstance(t, ast.Name) and t.id in all_typing:
+                    shadowed.add(t.id)
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if node.name in all_typing:
+                shadowed.add(node.name)
+        elif isinstance(node, ast.ClassDef):
+            if node.name in all_typing:
+                shadowed.add(node.name)
+    return frozenset(shadowed)
+
+
 def _collect_typing_bound_names(tree: ast.Module) -> frozenset[str]:
     """Names actually imported from typing/typing_extensions in this module.
 
@@ -158,31 +183,64 @@ def _collect_typing_bound_names(tree: ast.Module) -> frozenset[str]:
     return frozenset(bound)
 
 
-def _rhs_is_type_construct(node: ast.expr, typing_bound: frozenset[str] = frozenset()) -> bool:
+def _quote_unresolved_names(node: ast.expr, all_known: set[str]) -> ast.expr:
+    """Return a deep copy of node with unresolved Name refs replaced by string literals.
+
+    Produces forward references like Union["UnknownType", KnownType] so the
+    hoisted assignment is valid Python even when the name is defined later
+    (same-file) or in another module (cross-context).
+    """
+    node = copy.deepcopy(node)
+    for parent in ast.walk(node):
+        for field, val in ast.iter_fields(parent):
+            if isinstance(val, ast.Name) and val.id not in all_known:
+                setattr(parent, field, ast.Constant(value=val.id))
+            elif isinstance(val, list):
+                for i, item in enumerate(val):
+                    if isinstance(item, ast.Name) and item.id not in all_known:
+                        val[i] = ast.Constant(value=item.id)
+    return node
+
+
+def _rhs_is_type_construct(
+    node: ast.expr,
+    typing_bound: frozenset[str] = frozenset(),
+    local_shadows: frozenset[str] = frozenset(),
+) -> bool:
     """Check if an assignment RHS is a typing construct.
 
     This is the ONE narrow heuristic we still need because symtable
     can't distinguish `X = Literal["a"]` (type alias) from `x = foo()` (runtime).
 
     We check the VALUE, not the name. `typing_bound` extends the static sets with
-    names actually imported from typing/typing_extensions in the current file,
-    so provenance is verified rather than just string-matched.
+    names actually imported from typing/typing_extensions in the current file.
+    `local_shadows` removes names from the static sets that were redefined at module
+    scope (e.g. `List = []` or `def TypeVar(...)`), preventing wrong hoists.
     """
-    all_subscript = _TYPING_SUBSCRIPT_NAMES | typing_bound
-    all_functional = _TYPING_FUNCTIONAL_NAMES | typing_bound
+    all_subscript = (_TYPING_SUBSCRIPT_NAMES | typing_bound) - local_shadows
+    all_functional = (_TYPING_FUNCTIONAL_NAMES | typing_bound) - local_shadows
 
     # X = Literal[...], X = Dict[str, Any], X = list[Foo], X = Union[...]
     # Also handles typing.Optional[int] where node.value is ast.Attribute
     if isinstance(node, ast.Subscript):
         val = node.value
+        head_ok = False
         if isinstance(val, ast.Name):
-            return val.id in all_subscript
-        if isinstance(val, ast.Attribute):
-            return (
+            head_ok = val.id in all_subscript
+        elif isinstance(val, ast.Attribute):
+            head_ok = (
                 isinstance(val.value, ast.Name)
                 and val.value.id in _TYPING_MODULES
                 and val.attr in all_subscript
             )
+        if head_ok:
+            # Reject dynamic subscripts like Literal[*runtime_list] — the slice
+            # contains a starred unpack whose value is a runtime variable, not a
+            # static type expression. Hoisting this would produce a NameError.
+            if any(isinstance(n, ast.Starred) for n in ast.walk(node.slice)):
+                return False
+            return True
+        return False
     # X = str | int | None — new-style union.
     # _is_type_union_leaf validates every leaf strictly, so FLAGS = 1 | 2 and
     # READ | WRITE are both rejected without a separate anchor check.
@@ -221,6 +279,7 @@ def _extract_type_definitions(code: str) -> Tuple[str, str, str]:
         return "", "", code
 
     typing_bound = _collect_typing_bound_names(tree)
+    local_shadows = _collect_local_shadows(tree)
 
     lines = code.split('\n')
 
@@ -309,9 +368,37 @@ def _extract_type_definitions(code: str) -> Tuple[str, str, str]:
                     prune_queue.append(cls_name)
         module_scope_names -= to_remove
 
+    # Phase 3c: Prune module_scope_names — remove assignment targets whose RHS
+    # contains a starred subscript (e.g. Literal[*runtime_list]).  These are
+    # dynamic type expressions that require a runtime value not available at
+    # module scope; hoisting them produces a NameError or used-before-def.
+    # Cascade using the same logic as Phase 3b.
+    dynamic_names: set[str] = set()
+    for _node in ast.iter_child_nodes(tree):
+        if isinstance(_node, ast.Assign):
+            if any(isinstance(n, ast.Starred) for n in ast.walk(_node.value)):
+                for t in _node.targets:
+                    if isinstance(t, ast.Name) and t.id in module_scope_names:
+                        dynamic_names.add(t.id)
+
+    if dynamic_names:
+        dyn_remove: set[str] = set(dynamic_names)
+        dyn_queue = list(dynamic_names)
+        while dyn_queue:
+            dyn_name = dyn_queue.pop()
+            for cls_name in list(module_scope_names - dyn_remove):
+                if cls_name not in child_tables:
+                    continue
+                deps = _collect_free_names(child_tables[cls_name]) | class_outer_deps.get(cls_name, set())
+                if dyn_name in deps:
+                    dyn_remove.add(cls_name)
+                    dyn_queue.append(cls_name)
+        module_scope_names -= dyn_remove
+
     # Phase 4: Classify each AST node using the symtable results
     type_import_lines: set[int] = set()
     type_def_lines: set[int] = set()
+    modified_type_lines: dict[int, str] = {}  # line index -> replacement source
 
     prev_was_type_def = False
 
@@ -377,10 +464,14 @@ def _extract_type_definitions(code: str) -> Tuple[str, str, str]:
 
     # Phase 5: Also promote assignments that LOOK like type aliases
     # even if no class references them yet.
-    # This catches stuff like: DatadogStatus = Literal[...] when only used by functions
-    # symtable can't distinguish type aliases from variables,
-    # so this is the ONE remaining heuristic — but scoped narrowly to
-    # assignments whose RHS is a typing construct (Subscript/BinOp with |)
+    # This catches stuff like: DatadogStatus = Literal[...] when only used by functions.
+    # symtable can't distinguish type aliases from variables, so this is the ONE
+    # remaining heuristic — scoped narrowly to typing-construct RHS shapes.
+    #
+    # Unresolved names (defined later in the same file or in another module) are
+    # replaced with string forward references via _quote_unresolved_names so the
+    # hoisted line is always valid Python and mypy can resolve same-file refs.
+    all_known_names = _BUILTIN_TYPE_NAMES | typing_bound | module_scope_names
     for node in ast.iter_child_nodes(tree):
         if not isinstance(node, ast.Assign):
             continue
@@ -388,12 +479,32 @@ def _extract_type_definitions(code: str) -> Tuple[str, str, str]:
             t.id for t in node.targets
             if isinstance(t, ast.Name) and t.id not in module_scope_names
         ]
-        if new_names and _rhs_is_type_construct(node.value, typing_bound):
-            start = node.lineno - 1
-            end = getattr(node, 'end_lineno', None) or start + 1
-            for i in range(start, end):
-                type_def_lines.add(i)
-            module_scope_names.update(new_names)
+        if not new_names or not _rhs_is_type_construct(node.value, typing_bound, local_shadows):
+            continue
+
+        start = node.lineno - 1
+        end = getattr(node, 'end_lineno', None) or start + 1
+
+        unresolved = {
+            n.id for n in ast.walk(node.value)
+            if isinstance(n, ast.Name) and n.id not in all_known_names
+        }
+        if unresolved:
+            # Hoist with string-quoted forward refs for unknown names.
+            # Union["UnknownType", KnownType] is valid at runtime and mypy resolves
+            # same-file forward refs; cross-file refs degrade silently (unknown type).
+            quoted_rhs = _quote_unresolved_names(node.value, all_known_names)
+            target_src = ' = '.join(
+                t.id for t in node.targets if isinstance(t, ast.Name)
+            )
+            modified_type_lines[start] = f"{target_src} = {ast.unparse(quoted_rhs)}"
+            for i in range(start + 1, end):
+                modified_type_lines[i] = ''  # suppress continuation lines
+
+        for i in range(start, end):
+            type_def_lines.add(i)
+        module_scope_names.update(new_names)
+        all_known_names = all_known_names | set(new_names)
 
     # Build output
     imports_out: list[str] = []
@@ -403,7 +514,12 @@ def _extract_type_definitions(code: str) -> Tuple[str, str, str]:
         if i in type_import_lines:
             imports_out.append(line)
         elif i in type_def_lines:
-            types_out.append(line)
+            if i in modified_type_lines:
+                replacement = modified_type_lines[i]
+                if replacement:  # empty string = suppressed continuation line
+                    types_out.append(replacement)
+            else:
+                types_out.append(line)
         else:
             runtime_out.append(line)
 
@@ -442,6 +558,11 @@ def _wrap_code_in_try_except(function_name: str, code: str) -> Tuple[str, str]:
     )
 
     body = runtime_code if runtime_code.strip() else 'pass'
+
+    # polyConfig is re-declared in every client function's try block within the same
+    # __init__.py. Suppress the mypy no-redef error on that line in generated output.
+    body = re.sub(r'^(\s*polyConfig\s*:.*)', r'\1  # type: ignore[no-redef]', body, flags=re.MULTILINE)
+
     indented = '\n    '.join(body.split('\n'))
     wrapped = prefix + indented + suffix
 

--- a/polyapi/client.py
+++ b/polyapi/client.py
@@ -1,5 +1,6 @@
 import ast
 import copy
+import importlib
 import re
 import symtable as symtable_mod
 from typing import Any, Dict, List, Tuple
@@ -71,6 +72,24 @@ def _collect_free_names(table: symtable_mod.SymbolTable) -> set[str]:
     return names
 
 
+def _collect_class_body_names(table: symtable_mod.SymbolTable) -> set[str]:
+    """Collect module-referenced names evaluated at class definition time only.
+
+    Unlike _collect_free_names, this does NOT descend into function/method
+    scopes — method bodies run at call time, not when the class is defined.
+    Nested class scopes ARE descended because their bodies run at the enclosing
+    class's definition time.
+    """
+    names: set[str] = set()
+    for sym in table.get_symbols():
+        if sym.is_free() or (sym.is_global() and sym.is_referenced()):
+            names.add(sym.get_name())
+    for child in table.get_children():
+        if child.get_type() == 'class':
+            names.update(_collect_class_body_names(child))
+    return names
+
+
 def _import_bound_names(node: ast.stmt) -> set:
     """Names bound in the local namespace by an import statement."""
     if isinstance(node, (ast.Import, ast.ImportFrom)):
@@ -90,7 +109,19 @@ def _is_safe_import(node: ast.stmt) -> bool:
         )
     if isinstance(node, ast.ImportFrom):
         module = node.module or ''
-        return module.split('.')[0] in SAFE_IMPORT_MODULES
+        if module.split('.')[0] not in SAFE_IMPORT_MODULES:
+            return False
+        # The root module is safe, but a specific name may not exist 
+        # Verify each imported name is actually there so we don't hoist a from-import 
+        # Doing that would raise ImportError at module scope.
+        try:
+            mod = importlib.import_module(module)
+            return all(
+                alias.name == '*' or hasattr(mod, alias.name)
+                for alias in node.names
+            )
+        except ImportError:
+            return False
     return False
 
 
@@ -163,8 +194,10 @@ def _collect_local_shadows(tree: ast.Module) -> frozenset[str]:
     for node in ast.iter_child_nodes(tree):
         if isinstance(node, ast.Assign):
             for t in node.targets:
-                if isinstance(t, ast.Name) and t.id in all_typing:
-                    shadowed.add(t.id)
+                # Walk the target so destructuring like `Optional, other = ...` caught — the outer target is a Tuple, not a plain Name.
+                for name_node in ast.walk(t):
+                    if isinstance(name_node, ast.Name) and name_node.id in all_typing:
+                        shadowed.add(name_node.id)
         elif isinstance(node, ast.AnnAssign):
             if isinstance(node.target, ast.Name) and node.target.id in all_typing:
                 shadowed.add(node.target.id)
@@ -210,6 +243,45 @@ def _collect_typing_bound_names(tree: ast.Module) -> frozenset[str]:
     return frozenset(bound)
 
 
+def _dotted_name_info(node: ast.expr) -> tuple[str, str] | None:
+    """If node is a pure dotted name (a.b.c), return (root_name, full_dotted_str). Else None."""
+    parts: list[str] = []
+    n: ast.expr = node
+    while isinstance(n, ast.Attribute):
+        parts.append(n.attr)
+        n = n.value
+    if isinstance(n, ast.Name):
+        parts.append(n.id)
+        return n.id, '.'.join(reversed(parts))
+    return None
+
+
+def _quote_expr(node: ast.expr, all_known: set[str] | frozenset[str]) -> ast.expr:
+    """Recursively replace unresolved names with string constants.
+
+    Attribute chains (foo.Bar.Baz) whose root is unresolved are replaced with a
+    single string constant ("foo.Bar.Baz") rather than quoting only the base Name,
+    which would produce "foo".Bar.Baz — a string attribute lookup that raises at
+    module scope before the per-function import guard can fire.
+    """
+    if isinstance(node, ast.Name):
+        return ast.Constant(value=node.id) if node.id not in all_known else node
+    if isinstance(node, ast.Attribute):
+        info = _dotted_name_info(node)
+        if info is not None and info[0] not in all_known:
+            return ast.Constant(value=info[1])
+        node.value = _quote_expr(node.value, all_known)
+        return node
+    for field, val in ast.iter_fields(node):
+        if isinstance(val, ast.expr):
+            setattr(node, field, _quote_expr(val, all_known))
+        elif isinstance(val, list):
+            for i, item in enumerate(val):
+                if isinstance(item, ast.expr):
+                    val[i] = _quote_expr(item, all_known)
+    return node
+
+
 def _quote_unresolved_names(node: ast.expr, all_known: set[str] | frozenset[str]) -> ast.expr:
     """Return a deep copy of node with unresolved Name refs replaced by string literals.
 
@@ -217,16 +289,7 @@ def _quote_unresolved_names(node: ast.expr, all_known: set[str] | frozenset[str]
     hoisted assignment is valid Python even when the name is defined later
     (same-file) or in another module (cross-context).
     """
-    node = copy.deepcopy(node)
-    for parent in ast.walk(node):
-        for field, val in ast.iter_fields(parent):
-            if isinstance(val, ast.Name) and val.id not in all_known:
-                setattr(parent, field, ast.Constant(value=val.id))
-            elif isinstance(val, list):
-                for i, item in enumerate(val):
-                    if isinstance(item, ast.Name) and item.id not in all_known:
-                        val[i] = ast.Constant(value=item.id)
-    return node
+    return _quote_expr(copy.deepcopy(node), all_known)
 
 
 def _rhs_is_type_construct(
@@ -425,8 +488,40 @@ def _extract_type_definitions(code: str) -> Tuple[str, str, str]:
                     dyn_queue.append(cls_name)
         module_scope_names -= dyn_remove
 
+    # Phase 3d: Prune classes that depend on module-level functions at class-definition
+    # time. Functions are never hoisted (always runtime_out). If the class BODY
+    # (excluding method bodies, which only run at call time) references a local
+    # function, hoisting the class would crash at import time before the guard fires.
+    # We use _collect_class_body_names (non-recursive into function scopes) rather
+    # than _collect_free_names so that method-body refs to local functions don't
+    # cause unnecessary pruning.
+    local_function_names: set[str] = {
+        name for name, typ in child_types.items() if typ == 'function'
+    }
+    if local_function_names:
+        fn_remove: set[str] = set()
+        for cls_name in list(module_scope_names):
+            if cls_name not in child_tables:
+                continue
+            class_body_deps = _collect_class_body_names(child_tables[cls_name])
+            outer_deps = class_outer_deps.get(cls_name, set())
+            if (class_body_deps | outer_deps) & local_function_names:
+                fn_remove.add(cls_name)
+        # Cascade: classes that depended on just-removed classes also can't be hoisted
+        fn_queue = list(fn_remove)
+        while fn_queue:
+            removed = fn_queue.pop()
+            for cls_name in list(module_scope_names - fn_remove):
+                if cls_name not in child_tables:
+                    continue
+                deps = _collect_free_names(child_tables[cls_name]) | class_outer_deps.get(cls_name, set())
+                if removed in deps:
+                    fn_remove.add(cls_name)
+                    fn_queue.append(cls_name)
+        module_scope_names -= fn_remove
+
     # Names available at module scope: builtins, typing module names, anything that
-    # survived Phase 3b/3c, and names bound by safe imports (hoisted by Phase 4).
+    # survived Phase 3b/3c/3d, and names bound by safe imports (hoisted by Phase 4).
     # Used to guard Phase 4 assignment hoisting — if a RHS name isn't in this set
     # it won't be defined when the hoisted assignment runs.
     safe_import_bound: set[str] = set()
@@ -435,7 +530,7 @@ def _extract_type_definitions(code: str) -> Tuple[str, str, str]:
             safe_import_bound.update(_import_bound_names(_node))
     module_scope_available = (
         _BUILTIN_TYPE_NAMES | _TYPING_MODULES | module_scope_names | safe_import_bound
-    )
+    ) - local_shadows
 
     # Phase 4: Classify each AST node using the symtable results
     type_import_lines: set[int] = set()
@@ -461,6 +556,12 @@ def _extract_type_definitions(code: str) -> Tuple[str, str, str]:
         # Phase 3b pruning (unsafe-import cascade) is respected here too.
         elif isinstance(node, ast.ClassDef):
             is_type_def = node.name in module_scope_names
+            if is_type_def and node.decorator_list:
+                # node.lineno is the 'class' keyword line; decorators sit above it.
+                # Extend start backwards so the decorator lines are hoisted with the
+                # class — otherwise a dangling decorator stays in runtime_out and
+                # silently decorates the next generated function.
+                start = node.decorator_list[0].lineno - 1
 
         # type aliases (Python 3.12+): type X = ...
         elif hasattr(ast, 'TypeAlias') and isinstance(node, ast.TypeAlias):
@@ -475,7 +576,9 @@ def _extract_type_definitions(code: str) -> Tuple[str, str, str]:
         # STATUS = SomeType can land in module_scope_names via BFS without
         # SomeType being checked, causing a NameError when hoisted.
         elif isinstance(node, ast.Assign):
-            target_in_scope = any(
+            # Require ALL targets to be in scope: a chained `a = b = expr` would
+            # drag non-scope targets to module scope if we used `any()` here.
+            target_in_scope = bool(node.targets) and all(
                 isinstance(t, ast.Name) and t.id in module_scope_names
                 for t in node.targets
             )
@@ -621,7 +724,13 @@ def _wrap_code_in_try_except(function_name: str, code: str) -> Tuple[str, str]:
         f"'{function_name}', function unavailable: \" + str(e))"
     )
 
-    body = runtime_code if runtime_code.strip() else 'pass'
+    # A comment-only runtime block is syntactically empty — `try:` with nothing
+    # but comments raises IndentationError. Check for at least one real statement.
+    has_code = any(
+        l.strip() and not l.strip().startswith('#')
+        for l in runtime_code.split('\n')
+    )
+    body = runtime_code if has_code else 'pass'
 
     # polyConfig is re-declared in every client function's try block within the same
     # __init__.py. Suppress the mypy no-redef error on that line in generated output.

--- a/polyapi/client.py
+++ b/polyapi/client.py
@@ -157,12 +157,31 @@ def _collect_local_shadows(tree: ast.Module) -> frozenset[str]:
             for t in node.targets:
                 if isinstance(t, ast.Name) and t.id in all_typing:
                     shadowed.add(t.id)
+        elif isinstance(node, ast.AnnAssign):
+            if isinstance(node.target, ast.Name) and node.target.id in all_typing:
+                shadowed.add(node.target.id)
         elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
             if node.name in all_typing:
                 shadowed.add(node.name)
         elif isinstance(node, ast.ClassDef):
             if node.name in all_typing:
                 shadowed.add(node.name)
+        elif isinstance(node, ast.ImportFrom):
+            # A non-typing import that binds a typing-looking name shadows it.
+            # Phase 5 would otherwise trust the static whitelist and hoist
+            # X = Optional[str] even when Optional came from a third-party module
+            # whose import stays in the try block — producing a NameError.
+            module = node.module or ''
+            if module.split('.')[0] not in _TYPING_MODULES:
+                for alias in node.names:
+                    bound = alias.asname or alias.name
+                    if bound in all_typing:
+                        shadowed.add(bound)
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                bound = alias.asname or alias.name.split('.')[0]
+                if bound in all_typing:
+                    shadowed.add(bound)
     return frozenset(shadowed)
 
 
@@ -218,7 +237,10 @@ def _rhs_is_type_construct(
     scope (e.g. `List = []` or `def TypeVar(...)`), preventing wrong hoists.
     """
     all_subscript = (_TYPING_SUBSCRIPT_NAMES | typing_bound) - local_shadows
-    all_functional = (_TYPING_FUNCTIONAL_NAMES | typing_bound) - local_shadows
+    # Don't extend all_functional with typing_bound — typing_bound includes utilities
+    # like cast/overload/get_type_hints which are not type constructors. The static
+    # list covers all legitimate functional type forms (TypeVar, TypedDict, NewType...).
+    all_functional = _TYPING_FUNCTIONAL_NAMES - local_shadows
 
     # X = Literal[...], X = Dict[str, Any], X = list[Foo], X = Union[...]
     # Also handles typing.Optional[int] where node.value is ast.Attribute
@@ -415,13 +437,17 @@ def _extract_type_definitions(code: str) -> Tuple[str, str, str]:
         if isinstance(node, (ast.Import, ast.ImportFrom)):
             is_type_import = _is_safe_import(node)
 
-        # Class definitions: symtable confirmed these are classes
+        # Class definitions: use module_scope_names not class_names so that
+        # Phase 3b pruning (unsafe-import cascade) is respected here too.
         elif isinstance(node, ast.ClassDef):
-            is_type_def = node.name in class_names  # always True, but explicit
+            is_type_def = node.name in module_scope_names
 
         # type aliases (Python 3.12+): type X = ...
         elif hasattr(ast, 'TypeAlias') and isinstance(node, ast.TypeAlias):
-            is_type_def = True
+            is_type_def = (
+                isinstance(node.name, ast.Name)
+                and node.name.id in module_scope_names
+            )
 
         # Assignments: check if any target is in our module_scope_names set.
         # Handles both single (X = ...) and chained (X = Y = ...) assignments.
@@ -485,15 +511,19 @@ def _extract_type_definitions(code: str) -> Tuple[str, str, str]:
         start = node.lineno - 1
         end = getattr(node, 'end_lineno', None) or start + 1
 
+        # _TYPING_MODULES are module names (typing, typing_extensions), not bound names —
+        # they're never in all_known_names but must not be quoted or the generated
+        # expression becomes invalid Python (e.g. "typing".Optional[int]).
+        quotable_known = all_known_names | _TYPING_MODULES
         unresolved = {
             n.id for n in ast.walk(node.value)
-            if isinstance(n, ast.Name) and n.id not in all_known_names
+            if isinstance(n, ast.Name) and n.id not in quotable_known
         }
         if unresolved:
             # Hoist with string-quoted forward refs for unknown names.
             # Union["UnknownType", KnownType] is valid at runtime and mypy resolves
             # same-file forward refs; cross-file refs degrade silently (unknown type).
-            quoted_rhs = _quote_unresolved_names(node.value, all_known_names)
+            quoted_rhs = _quote_unresolved_names(node.value, quotable_known)
             target_src = ' = '.join(
                 t.id for t in node.targets if isinstance(t, ast.Name)
             )

--- a/polyapi/client.py
+++ b/polyapi/client.py
@@ -12,6 +12,14 @@ from typing import List, Dict, Any, TypedDict
 {return_type_def}
 """
 
+_TYPING_SUBSCRIPT_NAMES = frozenset({
+    'Literal', 'Dict', 'List', 'Set', 'FrozenSet', 'Tuple', 'Type',
+    'Optional', 'Union', 'ClassVar', 'Final', 'Annotated', 'Required',
+    'NotRequired', 'ReadOnly',
+    # lowercase generics (3.9+)
+    'dict', 'list', 'set', 'frozenset', 'tuple', 'type',
+})
+
 
 def _is_safe_import(node: ast.stmt) -> bool:
     """Check if an import statement is safe to place at module scope.
@@ -38,8 +46,8 @@ def _rhs_is_type_construct(node: ast.expr) -> bool:
     We check the VALUE, not the name — much more reliable than naming conventions.
     """
     # X = Literal[...], X = Dict[str, Any], X = list[Foo], X = Union[...]
-    if isinstance(node, ast.Subscript):
-        return True
+    if isinstance(node, ast.Subscript) and isinstance(node.value, ast.Name):
+        return node.value.id in _TYPING_SUBSCRIPT_NAMES
     # X = str | int | float new Union
     if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
         return True

--- a/polyapi/client.py
+++ b/polyapi/client.py
@@ -94,30 +94,38 @@ def _is_safe_import(node: ast.stmt) -> bool:
     return False
 
 
-def _is_type_union_leaf(node: ast.expr) -> bool:
+def _is_type_union_leaf(
+    node: ast.expr,
+    local_shadows: frozenset[str] = frozenset(),
+) -> bool:
     """Return True if node is a valid leaf in a new-style type union (X | Y | None).
 
     Every leaf must be an unambiguous type — we reject anything that could
     plausibly be a runtime value (flag constant, arbitrary subscript, etc.).
+    local_shadows removes whitelisted names that were redefined at module scope
+    (e.g. `Optional = []`), so they are not trusted as typing constructs.
     """
     if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
-        return _is_type_union_leaf(node.left) and _is_type_union_leaf(node.right)
-    # Name: only known typing / builtin type names (rejects READ, WRITE, etc.)
+        return (
+            _is_type_union_leaf(node.left, local_shadows)
+            and _is_type_union_leaf(node.right, local_shadows)
+        )
+    # Name: only known typing / builtin type names, minus any local shadows.
     if isinstance(node, ast.Name):
-        return node.id in _BUILTIN_TYPE_NAMES
+        return node.id in (_BUILTIN_TYPE_NAMES - local_shadows)
     # Attribute: only from typing / typing_extensions (rejects os.O_RDONLY, etc.)
     if isinstance(node, ast.Attribute):
         return isinstance(node.value, ast.Name) and node.value.id in _TYPING_MODULES
-    # Subscript: head must itself be a known typing name (rejects my_list[0], etc.)
+    # Subscript: head must itself be a known typing name, minus any local shadows.
     if isinstance(node, ast.Subscript):
         val = node.value
         if isinstance(val, ast.Name):
-            return val.id in _TYPING_SUBSCRIPT_NAMES
+            return val.id in (_TYPING_SUBSCRIPT_NAMES - local_shadows)
         if isinstance(val, ast.Attribute):
             return (
                 isinstance(val.value, ast.Name)
                 and val.value.id in _TYPING_MODULES
-                and val.attr in _TYPING_SUBSCRIPT_NAMES
+                and val.attr in (_TYPING_SUBSCRIPT_NAMES - local_shadows)
             )
         return False
     if isinstance(node, ast.Constant) and node.value is None:
@@ -202,7 +210,7 @@ def _collect_typing_bound_names(tree: ast.Module) -> frozenset[str]:
     return frozenset(bound)
 
 
-def _quote_unresolved_names(node: ast.expr, all_known: set[str]) -> ast.expr:
+def _quote_unresolved_names(node: ast.expr, all_known: set[str] | frozenset[str]) -> ast.expr:
     """Return a deep copy of node with unresolved Name refs replaced by string literals.
 
     Produces forward references like Union["UnknownType", KnownType] so the
@@ -267,7 +275,7 @@ def _rhs_is_type_construct(
     # _is_type_union_leaf validates every leaf strictly, so FLAGS = 1 | 2 and
     # READ | WRITE are both rejected without a separate anchor check.
     if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
-        return _is_type_union_leaf(node) and _union_has_type_anchor(node)
+        return _is_type_union_leaf(node, local_shadows) and _union_has_type_anchor(node)
     # X = TypedDict("X", {...}), T = TypeVar("T"), P = ParamSpec("P"), ...
     # Also handles typing.TypedDict(...) where node.func is ast.Attribute
     if isinstance(node, ast.Call):

--- a/polyapi/client.py
+++ b/polyapi/client.py
@@ -141,25 +141,47 @@ def _union_has_type_anchor(node: ast.expr) -> bool:
     return False
 
 
-def _rhs_is_type_construct(node: ast.expr) -> bool:
+def _collect_typing_bound_names(tree: ast.Module) -> frozenset[str]:
+    """Names actually imported from typing/typing_extensions in this module.
+
+    Used to validate RHS names by provenance rather than a static whitelist,
+    so `X = MyAlias[str]` is only hoisted if MyAlias came from a typing import
+    in this file — not just because the name string happens to look typing-ish.
+    """
+    bound: set[str] = set()
+    for node in ast.iter_child_nodes(tree):
+        if isinstance(node, ast.ImportFrom):
+            module = node.module or ''
+            if module.split('.')[0] in _TYPING_MODULES:
+                for alias in node.names:
+                    bound.add(alias.asname or alias.name)
+    return frozenset(bound)
+
+
+def _rhs_is_type_construct(node: ast.expr, typing_bound: frozenset[str] = frozenset()) -> bool:
     """Check if an assignment RHS is a typing construct.
 
     This is the ONE narrow heuristic we still need because symtable
     can't distinguish `X = Literal["a"]` (type alias) from `x = foo()` (runtime).
 
-    We check the VALUE, not the name — much more reliable than naming conventions.
+    We check the VALUE, not the name. `typing_bound` extends the static sets with
+    names actually imported from typing/typing_extensions in the current file,
+    so provenance is verified rather than just string-matched.
     """
+    all_subscript = _TYPING_SUBSCRIPT_NAMES | typing_bound
+    all_functional = _TYPING_FUNCTIONAL_NAMES | typing_bound
+
     # X = Literal[...], X = Dict[str, Any], X = list[Foo], X = Union[...]
     # Also handles typing.Optional[int] where node.value is ast.Attribute
     if isinstance(node, ast.Subscript):
         val = node.value
         if isinstance(val, ast.Name):
-            return val.id in _TYPING_SUBSCRIPT_NAMES
+            return val.id in all_subscript
         if isinstance(val, ast.Attribute):
             return (
                 isinstance(val.value, ast.Name)
                 and val.value.id in _TYPING_MODULES
-                and val.attr in _TYPING_SUBSCRIPT_NAMES
+                and val.attr in all_subscript
             )
     # X = str | int | None — new-style union.
     # _is_type_union_leaf validates every leaf strictly, so FLAGS = 1 | 2 and
@@ -171,12 +193,12 @@ def _rhs_is_type_construct(node: ast.expr) -> bool:
     if isinstance(node, ast.Call):
         func = node.func
         if isinstance(func, ast.Name):
-            return func.id in _TYPING_FUNCTIONAL_NAMES
+            return func.id in all_functional
         if isinstance(func, ast.Attribute):
             return (
                 isinstance(func.value, ast.Name)
                 and func.value.id in _TYPING_MODULES
-                and func.attr in _TYPING_FUNCTIONAL_NAMES
+                and func.attr in all_functional
             )
     return False
 
@@ -197,6 +219,8 @@ def _extract_type_definitions(code: str) -> Tuple[str, str, str]:
         st = symtable_mod.symtable(code, '<client_fn>', 'exec')
     except SyntaxError:
         return "", "", code
+
+    typing_bound = _collect_typing_bound_names(tree)
 
     lines = code.split('\n')
 
@@ -344,7 +368,7 @@ def _extract_type_definitions(code: str) -> Tuple[str, str, str]:
             t.id for t in node.targets
             if isinstance(t, ast.Name) and t.id not in module_scope_names
         ]
-        if new_names and _rhs_is_type_construct(node.value):
+        if new_names and _rhs_is_type_construct(node.value, typing_bound):
             start = node.lineno - 1
             end = getattr(node, 'end_lineno', None) or start + 1
             for i in range(start, end):

--- a/polyapi/client.py
+++ b/polyapi/client.py
@@ -21,6 +21,13 @@ _TYPING_SUBSCRIPT_NAMES = frozenset({
 })
 
 
+def _import_bound_names(node: ast.stmt) -> set:
+    """Names bound in the local namespace by an import statement."""
+    if isinstance(node, (ast.Import, ast.ImportFrom)):
+        return {alias.asname or alias.name.split('.')[0] for alias in node.names}
+    return set()
+
+
 def _is_safe_import(node: ast.stmt) -> bool:
     """Check if an import statement is safe to place at module scope.
 
@@ -98,23 +105,43 @@ def _extract_type_definitions(code: str) -> Tuple[str, str, str]:
     # must also be at module scope
     module_scope_names: set[str] = set(class_names)
 
-    # Get all module-level assigned symbol names for reference
+    # Get all module-level assigned symbol names for reference (imports count as assigned)
     module_level_symbols: set[str] = {
         sym.get_name() for sym in st.get_symbols() if sym.is_assigned()
     }
+
+    # AST-level deps from base classes and decorators: symtable misses these
+    # because they're evaluated in the enclosing scope, not the class body.
+    # e.g. `class A(pydantic.BaseModel)` — `pydantic` is in the module scope,
+    # not in the class body's symbol table.
+    class_outer_deps: dict[str, set[str]] = {}
+    for _node in ast.iter_child_nodes(tree):
+        if isinstance(_node, ast.ClassDef) and _node.name in class_names:
+            outer: set[str] = set()
+            exprs = list(_node.bases) + [kw.value for kw in _node.keywords] + list(_node.decorator_list)
+            for expr in exprs:
+                for n in ast.walk(expr):
+                    if isinstance(n, ast.Name):
+                        outer.add(n.id)
+            class_outer_deps[_node.name] = outer
 
     # BFS: find all module-level symbols reachable from classes
     queue = list(class_names)
     while queue:
         name = queue.pop()
-        if name not in child_tables:
-            continue
-        for sym in child_tables[name].get_symbols():
-            if sym.is_free() or (sym.is_global() and sym.is_referenced()):
-                dep = sym.get_name()
-                if dep in module_level_symbols and dep not in module_scope_names:
-                    module_scope_names.add(dep)
-                    queue.append(dep)  # transitively check this dep's deps
+        # deps from class body via symtable
+        if name in child_tables:
+            for sym in child_tables[name].get_symbols():
+                if sym.is_free() or (sym.is_global() and sym.is_referenced()):
+                    dep = sym.get_name()
+                    if dep in module_level_symbols and dep not in module_scope_names:
+                        module_scope_names.add(dep)
+                        queue.append(dep)
+        # deps from base classes and decorators (not visible in class body symtable)
+        for dep in class_outer_deps.get(name, set()):
+            if dep in module_level_symbols and dep not in module_scope_names:
+                module_scope_names.add(dep)
+                queue.append(dep)
 
     # Phase 4: Classify each AST node using the symtable results
     type_import_lines: set[int] = set()
@@ -129,9 +156,13 @@ def _extract_type_definitions(code: str) -> Tuple[str, str, str]:
         is_type_import = False
         is_type_def = False
 
-        # Imports: safe typing/stdlib imports go to module scope
+        # Imports: safe typing/stdlib imports go to module scope;
+        # also promote any import that binds a name required by a module-scope class.
         if isinstance(node, (ast.Import, ast.ImportFrom)):
-            is_type_import = _is_safe_import(node)
+            is_type_import = (
+                _is_safe_import(node)
+                or bool(_import_bound_names(node) & module_scope_names)
+            )
 
         # Class definitions: symtable confirmed these are classes
         elif isinstance(node, ast.ClassDef):

--- a/polyapi/client.py
+++ b/polyapi/client.py
@@ -287,6 +287,28 @@ def _extract_type_definitions(code: str) -> Tuple[str, str, str]:
                 module_scope_names.add(dep)
                 queue.append(dep)
 
+    # Phase 3b: Prune module_scope_names — remove names bound by non-safe imports,
+    # then cascade: any class that depends on a pruned name can't safely sit at module
+    # scope either (its base class / decorator would be undefined if the dep is missing).
+    unsafe_import_names: set[str] = set()
+    for _node in ast.iter_child_nodes(tree):
+        if isinstance(_node, (ast.Import, ast.ImportFrom)) and not _is_safe_import(_node):
+            unsafe_import_names.update(_import_bound_names(_node) & module_scope_names)
+
+    if unsafe_import_names:
+        to_remove: set[str] = set(unsafe_import_names)
+        prune_queue = list(unsafe_import_names)
+        while prune_queue:
+            unsafe_name = prune_queue.pop()
+            for cls_name in list(module_scope_names - to_remove):
+                if cls_name not in child_tables:
+                    continue
+                deps = _collect_free_names(child_tables[cls_name]) | class_outer_deps.get(cls_name, set())
+                if unsafe_name in deps:
+                    to_remove.add(cls_name)
+                    prune_queue.append(cls_name)
+        module_scope_names -= to_remove
+
     # Phase 4: Classify each AST node using the symtable results
     type_import_lines: set[int] = set()
     type_def_lines: set[int] = set()
@@ -300,13 +322,11 @@ def _extract_type_definitions(code: str) -> Tuple[str, str, str]:
         is_type_import = False
         is_type_def = False
 
-        # Imports: safe typing/stdlib imports go to module scope;
-        # also promote any import that binds a name required by a module-scope class.
+        # Imports: only safe (stdlib/typing) imports go to module scope.
+        # Non-safe imports stay in try/except — hoisting them risks crashing the whole
+        # generated module if the dependency is missing (before the guard can fire).
         if isinstance(node, (ast.Import, ast.ImportFrom)):
-            is_type_import = (
-                _is_safe_import(node)
-                or bool(_import_bound_names(node) & module_scope_names)
-            )
+            is_type_import = _is_safe_import(node)
 
         # Class definitions: symtable confirmed these are classes
         elif isinstance(node, ast.ClassDef):

--- a/polyapi/client.py
+++ b/polyapi/client.py
@@ -123,8 +123,8 @@ def _extract_type_definitions(code: str) -> Tuple[str, str, str]:
     prev_was_type_def = False
 
     for node in ast.iter_child_nodes(tree):
-        start = node.lineno - 1
-        end = node.end_lineno or start + 1
+        start = getattr(node, 'lineno', 1) - 1
+        end = getattr(node, 'end_lineno', None) or start + 1
 
         is_type_import = False
         is_type_def = False
@@ -183,7 +183,7 @@ def _extract_type_definitions(code: str) -> Tuple[str, str, str]:
             if isinstance(target, ast.Name) and target.id not in module_scope_names:
                 if _rhs_is_type_construct(node.value):
                     start = node.lineno - 1
-                    end = node.end_lineno or start + 1
+                    end = getattr(node, 'end_lineno', None) or start + 1
                     for i in range(start, end):
                         type_def_lines.add(i)
                     module_scope_names.add(target.id)

--- a/polyapi/client.py
+++ b/polyapi/client.py
@@ -1,7 +1,10 @@
+import ast
+import symtable as symtable_mod
 from typing import Any, Dict, List, Tuple
 
 from polyapi.typedefs import PropertySpecification
 from polyapi.utils import parse_arguments, get_type_and_def
+from polyapi.constants import SAFE_IMPORT_MODULES
 
 DEFS_TEMPLATE = """
 from typing import List, Dict, Any, TypedDict
@@ -10,20 +13,223 @@ from typing import List, Dict, Any, TypedDict
 """
 
 
-def _wrap_code_in_try_except(function_name: str, code: str) -> str:
-    """ this is necessary because client functions with imports will blow up ALL server functions,
-    even if they don't use them.
-    because the server function will try to load all client functions when loading the library
-    """
-    prefix = """logger = logging.getLogger("poly")
-try:
-    """
-    suffix = f"""except ImportError as e:
-    logger.warning("Failed to import client function '{function_name}', function unavailable: " + str(e))"""
+def _is_safe_import(node: ast.stmt) -> bool:
+    """Check if an import statement is safe to place at module scope.
 
-    lines = code.split("\n")
-    code = "\n    ".join(lines)
-    return "".join([prefix, code, "\n", suffix])
+    Safe imports are stdlib and typing modules that will never raise ImportError.
+    """
+    if isinstance(node, ast.Import):
+        return all(
+            alias.name.split('.')[0] in SAFE_IMPORT_MODULES
+            for alias in node.names
+        )
+    if isinstance(node, ast.ImportFrom):
+        module = node.module or ''
+        return module.split('.')[0] in SAFE_IMPORT_MODULES
+    return False
+
+
+def _rhs_is_type_construct(node: ast.expr) -> bool:
+    """Check if an assignment RHS is a typing construct.
+
+    This is the ONE narrow heuristic we still need because symtable
+    can't distinguish `X = Literal["a"]` (type alias) from `x = foo()` (runtime).
+
+    We check the VALUE, not the name — much more reliable than naming conventions.
+    """
+    # X = Literal[...], X = Dict[str, Any], X = list[Foo], X = Union[...]
+    if isinstance(node, ast.Subscript):
+        return True
+    # X = str | int | float new Union
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
+        return True
+    # X = TypedDict("X", {...}) — functional form
+    if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+        if node.func.id in ('TypedDict', 'NamedTuple', 'NewType'):
+            return True
+    return False
+
+
+def _extract_type_definitions(code: str) -> Tuple[str, str, str]:
+    """Split client function code into type definitions and runtime code.
+
+    Uses symtable for definitive classification + dependency tracking.
+    Uses AST only for source line extraction.
+
+    Returns:
+        (type_imports_code, type_defs_code, runtime_code)
+    """
+    try:
+        tree = ast.parse(code)
+        st = symtable_mod.symtable(code, '<client_fn>', 'exec')
+    except SyntaxError:
+        return "", "", code
+
+    lines = code.split('\n')
+
+    # Phase 1: Build child table index — name -> type ('class' | 'function')
+    child_types: dict[str, str] = {}
+    child_tables: dict[str, symtable_mod.SymbolTable] = {}
+    for child in st.get_children():
+        child_types[child.get_name()] = child.get_type()
+        child_tables[child.get_name()] = child
+
+    # Phase 2: Identify all class names — these are ALWAYS module-scope
+    class_names: set[str] = {
+        name for name, kind in child_types.items() if kind == 'class'
+    }
+
+    # Phase 2b: type aliases (Python 3.12+): type X = ...
+    if hasattr(ast, 'TypeAlias'):
+        for node in ast.iter_child_nodes(tree):
+            if isinstance(node, ast.TypeAlias) and isinstance(node.name, ast.Name):
+                class_names.add(node.name.id)
+
+    # Phase 3: Compute transitive dependencies of all classes
+    # Any module-level symbol that a class references (directly or transitively)
+    # must also be at module scope
+    module_scope_names: set[str] = set(class_names)
+
+    # Get all module-level assigned symbol names for reference
+    module_level_symbols: set[str] = {
+        sym.get_name() for sym in st.get_symbols() if sym.is_assigned()
+    }
+
+    # BFS: find all module-level symbols reachable from classes
+    queue = list(class_names)
+    while queue:
+        name = queue.pop()
+        if name not in child_tables:
+            continue
+        for sym in child_tables[name].get_symbols():
+            if sym.is_free() or (sym.is_global() and sym.is_referenced()):
+                dep = sym.get_name()
+                if dep in module_level_symbols and dep not in module_scope_names:
+                    module_scope_names.add(dep)
+                    queue.append(dep)  # transitively check this dep's deps
+
+    # Phase 4: Classify each AST node using the symtable results
+    type_import_lines: set[int] = set()
+    type_def_lines: set[int] = set()
+
+    prev_was_type_def = False
+
+    for node in ast.iter_child_nodes(tree):
+        start = node.lineno - 1
+        end = node.end_lineno or start + 1
+
+        is_type_import = False
+        is_type_def = False
+
+        # Imports: safe typing/stdlib imports go to module scope
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            is_type_import = _is_safe_import(node)
+
+        # Class definitions: symtable confirmed these are classes
+        elif isinstance(node, ast.ClassDef):
+            is_type_def = node.name in class_names  # always True, but explicit
+
+        # type aliases (Python 3.12+): type X = ...
+        elif hasattr(ast, 'TypeAlias') and isinstance(node, ast.TypeAlias):
+            is_type_def = True
+
+        # Assignments: check if target is in our module_scope_names set
+        elif isinstance(node, ast.Assign) and len(node.targets) == 1:
+            if isinstance(node.targets[0], ast.Name):
+                is_type_def = node.targets[0].id in module_scope_names
+
+        # Annotated assignments with value
+        elif isinstance(node, ast.AnnAssign) and node.value is not None:
+            if isinstance(node.target, ast.Name):
+                is_type_def = node.target.id in module_scope_names
+
+        # Function definitions: NEVER module scope (these are runtime)
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            is_type_def = False
+
+        # Docstrings following type defs: keep with them
+        elif (isinstance(node, ast.Expr)
+              and isinstance(node.value, ast.Constant)
+              and isinstance(node.value.value, str)
+              and prev_was_type_def):
+            is_type_def = True
+
+        if is_type_import:
+            for i in range(start, end):
+                type_import_lines.add(i)
+        if is_type_def:
+            for i in range(start, end):
+                type_def_lines.add(i)
+
+        prev_was_type_def = is_type_def or is_type_import
+
+    # Phase 5: Also promote assignments that LOOK like type aliases
+    # even if no class references them yet.
+    # This catches stuff like: DatadogStatus = Literal[...] when only used by functions
+    # symtable can't distinguish type aliases from variables,
+    # so this is the ONE remaining heuristic — but scoped narrowly to
+    # assignments whose RHS is a typing construct (Subscript/BinOp with |)
+    for node in ast.iter_child_nodes(tree):
+        if isinstance(node, ast.Assign) and len(node.targets) == 1:
+            target = node.targets[0]
+            if isinstance(target, ast.Name) and target.id not in module_scope_names:
+                if _rhs_is_type_construct(node.value):
+                    start = node.lineno - 1
+                    end = node.end_lineno or start + 1
+                    for i in range(start, end):
+                        type_def_lines.add(i)
+                    module_scope_names.add(target.id)
+
+    # Build output
+    imports_out: list[str] = []
+    types_out: list[str] = []
+    runtime_out: list[str] = []
+    for i, line in enumerate(lines):
+        if i in type_import_lines:
+            imports_out.append(line)
+        elif i in type_def_lines:
+            types_out.append(line)
+        else:
+            runtime_out.append(line)
+
+    return (
+        '\n'.join(imports_out).strip(),
+        '\n'.join(types_out).strip(),
+        '\n'.join(runtime_out).strip(),
+    )
+
+
+def _wrap_code_in_try_except(function_name: str, code: str) -> Tuple[str, str]:
+    """Split client code: types at module scope, runtime in try/except.
+
+    Returns:
+        (module_scope_code, try_except_code)
+
+        module_scope_code: safe imports + type definitions (always available)
+        try_except_code:   runtime code wrapped in try/except ImportError
+    """
+    type_imports, type_defs, runtime_code = _extract_type_definitions(code)
+
+    # Build module-scope section
+    module_parts = []
+    if type_imports:
+        module_parts.append(type_imports)
+    if type_defs:
+        module_parts.append(type_defs)
+    module_scope = '\n\n'.join(module_parts)
+
+    # Build try/except section for runtime code
+    prefix = f'logger = logging.getLogger("poly")\ntry:\n    '
+    suffix = (
+        f"\nexcept ImportError as e:\n"
+        f"    logger.warning(\"Failed to import client function "
+        f"'{function_name}', function unavailable: \" + str(e))"
+    )
+
+    indented = '\n    '.join(runtime_code.split('\n'))
+    wrapped = prefix + indented + suffix
+
+    return module_scope, wrapped
 
 
 def render_client_function(
@@ -31,7 +237,16 @@ def render_client_function(
     code: str,
     arguments: List[PropertySpecification],
     return_type: Dict[str, Any],
-) -> Tuple[str, str]:
+) -> Tuple[str, str, str]:
+    """Render a client function into three parts.
+
+    Returns:
+        (module_scope_types, wrapped_runtime, func_type_defs)
+
+        module_scope_types: type definitions to place at module scope (deduplicated by caller)
+        wrapped_runtime:    function code wrapped in try/except
+        func_type_defs:     SDK-generated type stubs for the {FuncName}.py file
+    """
     args, args_def = parse_arguments(function_name, arguments)
     return_type_name, return_type_def = get_type_and_def(return_type)  # type: ignore
     func_type_defs = DEFS_TEMPLATE.format(
@@ -39,6 +254,6 @@ def render_client_function(
         return_type_def=return_type_def,
     )
 
-    code = _wrap_code_in_try_except(function_name, code)
+    module_scope, wrapped = _wrap_code_in_try_except(function_name, code)
 
-    return code + "\n\n", func_type_defs
+    return module_scope, wrapped + "\n\n", func_type_defs

--- a/polyapi/constants.py
+++ b/polyapi/constants.py
@@ -23,6 +23,7 @@ PYTHON_TO_JSONSCHEMA_TYPE_MAP = {
 
 BASIC_PYTHON_TYPES = set(PYTHON_TO_JSONSCHEMA_TYPE_MAP.keys())
 
+# initial pass
 SAFE_IMPORT_MODULES = {
     "typing", "typing_extensions", "types",
     "re", "os", "sys", "json", "datetime", "math",

--- a/polyapi/constants.py
+++ b/polyapi/constants.py
@@ -23,5 +23,14 @@ PYTHON_TO_JSONSCHEMA_TYPE_MAP = {
 
 BASIC_PYTHON_TYPES = set(PYTHON_TO_JSONSCHEMA_TYPE_MAP.keys())
 
+SAFE_IMPORT_MODULES = {
+    "typing", "typing_extensions", "types",
+    "re", "os", "sys", "json", "datetime", "math",
+    "collections", "enum", "dataclasses", "abc",
+    "functools", "itertools", "operator",
+    "urllib", "urllib.parse", "pathlib",
+    "copy", "hashlib", "uuid",
+}
+
 # TODO wire this up to config-variables in future so clients can modify
 SUPPORT_EMAIL = 'support@polyapi.io'

--- a/polyapi/generate.py
+++ b/polyapi/generate.py
@@ -521,8 +521,8 @@ def _deduplicate_types(full_path: str, module_scope_types: str) -> str:
         if not name:
             continue
         
-        start = node.lineno - 1
-        end = node.end_lineno or start + 1
+        start = getattr(node, 'lineno', 1) - 1
+        end = getattr(node, 'end_lineno', None) or start + 1
         source = '\n'.join(lines[start:end])
         
         if name in seen and seen[name] == source:

--- a/polyapi/generate.py
+++ b/polyapi/generate.py
@@ -24,7 +24,7 @@ from . import http_client
 from .config import get_api_key_and_url, get_direct_execute_config, get_cached_generate_args
 
 # Track emitted type definitions per __init__.py for deduplication
-# Maps: directory_path -> {type_name -> source_code}
+# Maps: directory_path -> {type_name -> source_text}
 _emitted_types: dict[str, dict[str, str]] = {}
 
 

--- a/polyapi/generate.py
+++ b/polyapi/generate.py
@@ -4,6 +4,7 @@ import os
 import uuid
 import shutil
 import logging
+import ast
 import tempfile
 
 from copy import deepcopy
@@ -21,6 +22,11 @@ from .utils import add_import_to_init, get_auth_headers, init_the_init, print_gr
 from .variables import generate_variables
 from .poly_tables import generate_tables
 from .config import get_api_key_and_url, get_direct_execute_config, get_cached_generate_args
+
+# Track emitted type definitions per __init__.py for deduplication
+# Maps: directory_path -> {type_name -> source_code}
+_emitted_types: dict[str, dict[str, str]] = {}
+
 
 SUPPORTED_FUNCTION_TYPES = {
     "apiFunction",
@@ -342,7 +348,7 @@ def generate(contexts: Optional[List[str]] = None, names: Optional[List[str]] = 
     generate_msg = f"Generating Poly Python SDK for contexts ${contexts}..." if contexts else "Generating Poly Python SDK..."
     print(generate_msg, end="", flush=True)
     remove_old_library()
-
+    _emitted_types.clear()
     specs = get_specs(contexts=contexts, names=names, ids=ids, no_types=no_types)
     cache_specs(specs)
 
@@ -397,7 +403,16 @@ def clear() -> None:
     print("Cleared!")
 
 
-def render_spec(spec: SpecificationDto) -> Tuple[str, str]:
+def render_spec(spec: SpecificationDto) -> Tuple[str, str, str]:
+    """Render a spec into generated code.
+    
+    Returns:
+        (module_scope_types, func_str, func_type_defs)
+        
+        module_scope_types: type definitions for module scope (client functions only)
+        func_str:           function code (wrapped in try/except for client functions)
+        func_type_defs:     type stubs for the {FuncName}.py IDE helper file
+    """
     function_type = spec["type"]
     function_description = spec["description"]
     function_name = spec["name"]
@@ -410,10 +425,7 @@ def render_spec(spec: SpecificationDto) -> Tuple[str, str]:
         assert spec["function"]
         # Handle cases where arguments might be missing or None
         if spec["function"].get("arguments"):
-            arguments = [
-                arg for arg in spec["function"]["arguments"]
-            ]
-        
+            arguments = [arg for arg in spec["function"]["arguments"]]
         # Handle cases where returnType might be missing or None
         if spec["function"].get("returnType"):
             return_type = spec["function"]["returnType"]
@@ -421,49 +433,31 @@ def render_spec(spec: SpecificationDto) -> Tuple[str, str]:
             # Provide a fallback return type when missing
             return_type = {"kind": "any"}
 
+    module_scope_types = ""
+
     if function_type == "apiFunction":
         func_str, func_type_defs = render_api_function(
-            function_type,
-            function_name,
-            function_id,
-            function_description,
-            arguments,
-            return_type,
+            function_type, function_name, function_id,
+            function_description, arguments, return_type,
         )
     elif function_type == "customFunction":
-        func_str, func_type_defs = render_client_function(
-            function_name,
-            spec.get("code", ""),
-            arguments,
-            return_type,
+        module_scope_types, func_str, func_type_defs = render_client_function(
+            function_name, spec.get("code", ""), arguments, return_type,
         )
     elif function_type == "serverFunction":
         func_str, func_type_defs = render_server_function(
-            function_type,
-            function_name,
-            function_id,
-            function_description,
-            arguments,
-            return_type,
+            function_type, function_name, function_id,
+            function_description, arguments, return_type,
         )
     elif function_type == "authFunction":
         func_str, func_type_defs = render_auth_function(
-            function_type,
-            function_name,
-            function_id,
-            function_description,
-            arguments,
-            return_type,
+            function_type, function_name, function_id,
+            function_description, arguments, return_type,
         )
     elif function_type == "webhookHandle":
         func_str, func_type_defs = render_webhook_handle(
-            function_type,
-            function_context,
-            function_name,
-            function_id,
-            function_description,
-            arguments,
-            return_type,
+            function_type, function_context, function_name,
+            function_id, function_description, arguments, return_type,
         )
 
     if X_POLY_REF_WARNING in func_type_defs:
@@ -471,7 +465,62 @@ def render_spec(spec: SpecificationDto) -> Tuple[str, str]:
         # let's add a more user friendly error explaining what is going on
         func_type_defs = func_type_defs.replace(X_POLY_REF_WARNING, X_POLY_REF_BETTER_WARNING)
 
-    return func_str, func_type_defs
+    return module_scope_types, func_str, func_type_defs
+
+
+def _deduplicate_types(full_path: str, module_scope_types: str) -> str:
+    """Remove type definitions that have already been emitted for this context.
+    
+    Uses AST to parse the module_scope_types string, identifies each 
+    top-level definition by name, and strips duplicates.
+    
+    Keeps definitions whose name hasn't been seen, or whose content differs
+    from the previously emitted version (last-writer-wins for changed types).
+    """
+    if not module_scope_types.strip():
+        return ""
+    
+    if full_path not in _emitted_types:
+        _emitted_types[full_path] = {}
+    
+    seen = _emitted_types[full_path]
+    
+    try:
+        tree = ast.parse(module_scope_types)
+    except SyntaxError:
+        return module_scope_types  # Can't parse, emit as-is
+    
+    lines = module_scope_types.split('\n')
+    keep_lines: set[int] = set(range(len(lines)))  # Start by keeping all
+    
+    for node in ast.iter_child_nodes(tree):
+        name = None
+        if isinstance(node, ast.ClassDef):
+            name = node.name
+        elif isinstance(node, ast.Assign) and len(node.targets) == 1:
+            target = node.targets[0]
+            if isinstance(target, ast.Name):
+                name = target.id
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            name = node.target.id
+        
+        if not name:
+            continue
+        
+        start = node.lineno - 1
+        end = node.end_lineno or start + 1
+        source = '\n'.join(lines[start:end])
+        
+        if name in seen and seen[name] == source:
+            # Exact duplicate — skip it
+            for i in range(start, end):
+                keep_lines.discard(i)
+        else:
+            # New or changed — keep it, update registry
+            seen[name] = source
+    
+    return '\n'.join(line for i, line in enumerate(lines) if i in keep_lines).strip()
+
 
 
 def add_function_file(
@@ -479,62 +528,58 @@ def add_function_file(
     function_name: str,
     spec: SpecificationDto,
 ):
-    """
-    Atomically add a function file to prevent partial corruption during generation failures.
+    """Atomically add a function to a context's __init__.py.
     
-    This function generates all content first, then writes files atomically using temporary files
-    to ensure that either the entire operation succeeds or no changes are made to the filesystem.
+    For client functions, type definitions are placed at module scope
+    (outside try/except) and deduplicated across sibling functions.
     """
     try:
-        # first lets add the import to the __init__
         init_the_init(full_path)
 
-        func_str, func_type_defs = render_spec(spec)
+        module_scope_types, func_str, func_type_defs = render_spec(spec)
 
         if not func_str:
-            # If render_spec failed and returned empty string, don't create any files
             raise Exception("Function rendering failed - empty function string returned")
 
-        # Prepare all content first before writing any files
+        # Deduplicate types against previously emitted types for this context
+        unique_types = _deduplicate_types(full_path, module_scope_types)
+
         func_namespace = to_func_namespace(function_name)
         init_path = os.path.join(full_path, "__init__.py")
         func_file_path = os.path.join(full_path, f"{func_namespace}.py")
         
-        # Read current __init__.py content if it exists
         init_content = ""
         if os.path.exists(init_path):
             with open(init_path, "r", encoding='utf-8') as f:
                 init_content = f.read()
         
-        # Prepare new content to append to __init__.py
-        new_init_content = init_content + f"\n\nfrom . import {func_namespace}\n\n{func_str}"
+        # Build new content: import + module-scope types + wrapped function
+        new_parts = [init_content, f"\n\nfrom . import {func_namespace}\n"]
+        if unique_types:
+            new_parts.append(f"\n{unique_types}\n")
+        new_parts.append(f"\n{func_str}")
+        new_init_content = ''.join(new_parts)
         
-        # Use temporary files for atomic writes
-        # Write to __init__.py atomically
+        # Atomic writes
         with tempfile.NamedTemporaryFile(mode="w", delete=False, dir=full_path, suffix=".tmp", encoding='utf-8') as temp_init:
             temp_init.write(new_init_content)
             temp_init_path = temp_init.name
         
-        # Write to function file atomically  
         with tempfile.NamedTemporaryFile(mode="w", delete=False, dir=full_path, suffix=".tmp", encoding='utf-8') as temp_func:
             temp_func.write(func_type_defs)
             temp_func_path = temp_func.name
         
-        # Atomic operations: move temp files to final locations
         shutil.move(temp_init_path, init_path)
         shutil.move(temp_func_path, func_file_path)
         
     except Exception as e:
-        # Clean up any temporary files that might have been created
         try:
             if 'temp_init_path' in locals() and os.path.exists(temp_init_path):
                 os.unlink(temp_init_path)
             if 'temp_func_path' in locals() and os.path.exists(temp_func_path):
                 os.unlink(temp_func_path)
         except:
-            pass  # Best effort cleanup
-        
-        # Re-raise the original exception
+            pass
         raise e
 
 

--- a/polyapi/generate.py
+++ b/polyapi/generate.py
@@ -570,7 +570,8 @@ def add_function_file(
         # Import the generated type module under a private alias so PascalCase function
         # names do not shadow their own module symbol in __init__.py.
         type_module_alias = to_type_module_alias(function_name)
-        new_init_content = init_content + f"\n\nfrom . import {func_namespace} as {type_module_alias}\n\n{func_str}"
+        type_block = f"\n\n{unique_types}" if unique_types else ""
+        new_init_content = init_content + f"{type_block}\n\nfrom . import {func_namespace} as {type_module_alias}\n\n{func_str}"
         
         # Use temporary files for atomic writes
         # Write to __init__.py atomically

--- a/polyapi/generate.py
+++ b/polyapi/generate.py
@@ -522,6 +522,8 @@ def _deduplicate_types(full_path: str, module_scope_types: str) -> str:
             continue
         
         start = getattr(node, 'lineno', 1) - 1
+        if isinstance(node, ast.ClassDef) and node.decorator_list:
+            start = node.decorator_list[0].lineno - 1
         end = getattr(node, 'end_lineno', None) or start + 1
         source = '\n'.join(lines[start:end])
         

--- a/polyapi/rendered_spec.py
+++ b/polyapi/rendered_spec.py
@@ -9,7 +9,7 @@ from polyapi.typedefs import SpecificationDto
 
 def update_rendered_spec(spec: SpecificationDto):
     print("Updating rendered spec...")
-    func_str, type_defs = render_spec(spec)
+    _, func_str, type_defs = render_spec(spec)
     data = {
         "language": "python",
         "signature": func_str,

--- a/polyapi/utils.py
+++ b/polyapi/utils.py
@@ -16,8 +16,16 @@ from polyapi.schema import (
 
 # this string should be in every __init__ file.
 # it contains all the imports needed for the function or variable code to run
-CODE_IMPORTS = "from typing import List, Dict, Any, Optional, Callable\nfrom typing_extensions import TypedDict, NotRequired\nimport logging\nimport requests\nimport socketio  # type: ignore\nfrom polyapi.config import get_api_key_and_url, get_direct_execute_config\nfrom polyapi.execute import execute, execute_post, variable_get, variable_update, direct_execute\n\n"
-
+CODE_IMPORTS = (
+    "from __future__ import annotations\n"  # main char  
+    "from typing import List, Dict, Any, Optional, Callable, Union\n"
+    "from typing_extensions import TypedDict, NotRequired, Literal\n"
+    "import logging\n"
+    "import requests\n"
+    "import socketio  # type: ignore\n"
+    "from polyapi.config import get_api_key_and_url, get_direct_execute_config\n"
+    "from polyapi.execute import execute, execute_post, variable_get, variable_update, direct_execute\n\n"
+)
 
 def init_the_init(full_path: str, code_imports: Optional[str] = None) -> None:
     init_path = os.path.join(full_path, "__init__.py")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,337 @@
+import ast
+import unittest
+
+from polyapi.client import (
+    _extract_type_definitions,
+    _import_bound_names,
+    _is_safe_import,
+    _rhs_is_type_construct,
+    _wrap_code_in_try_except,
+    render_client_function
+)
+
+
+def _parse_stmt(src: str) -> ast.stmt:
+    return ast.parse(src).body[0]
+
+
+def _parse_expr(src: str) -> ast.expr:
+    return ast.parse(src, mode="eval").body
+
+
+class TestImportBoundNames(unittest.TestCase):
+    def test_simple_import(self):
+        self.assertEqual(_import_bound_names(_parse_stmt("import pydantic")), {"pydantic"})
+
+    def test_dotted_import_uses_root(self):
+        self.assertEqual(_import_bound_names(_parse_stmt("import os.path")), {"os"})
+
+    def test_import_with_alias(self):
+        self.assertEqual(_import_bound_names(_parse_stmt("import numpy as np")), {"np"})
+
+    def test_from_import(self):
+        self.assertEqual(_import_bound_names(_parse_stmt("from pydantic import BaseModel")), {"BaseModel"})
+
+    def test_from_import_with_alias(self):
+        self.assertEqual(_import_bound_names(_parse_stmt("from pydantic import BaseModel as BM")), {"BM"})
+
+    def test_multi_name_import(self):
+        self.assertEqual(
+            _import_bound_names(_parse_stmt("import os, sys")),
+            {"os", "sys"},
+        )
+
+    def test_non_import_node_returns_empty(self):
+        self.assertEqual(_import_bound_names(_parse_stmt("x = 555555")), set())
+
+
+# 
+# _is_safe_import
+# 
+
+class TestIsSafeImport(unittest.TestCase):
+    def test_typing_is_safe(self):
+        self.assertTrue(_is_safe_import(_parse_stmt("import typing")))
+
+    def test_from_typing_is_safe(self):
+        self.assertTrue(_is_safe_import(_parse_stmt("from typing import Optional")))
+
+    def test_stdlib_is_safe(self):
+        self.assertTrue(_is_safe_import(_parse_stmt("import os")))
+
+    def test_third_party_is_not_safe(self):
+        self.assertFalse(_is_safe_import(_parse_stmt("import pydantic")))
+
+    def test_from_third_party_is_not_safe(self):
+        self.assertFalse(_is_safe_import(_parse_stmt("from pydantic import BaseModel")))
+
+    def test_non_import_node_returns_false(self):
+        self.assertFalse(_is_safe_import(_parse_stmt("x = 666")))
+
+
+# 
+# _rhs_is_type_construct
+# 
+
+class TestRhsIsTypeConstruct(unittest.TestCase):
+    def _rhs(self, src: str) -> ast.expr:
+        return ast.parse(src).body[0].value  # type: ignore[attr-defined]
+
+    #  typing subscripts that SHOULD match 
+    def test_literal_subscript(self):
+        self.assertTrue(_rhs_is_type_construct(self._rhs('Literal["a", "b"]')))
+
+    def test_dict_subscript(self):
+        self.assertTrue(_rhs_is_type_construct(self._rhs("Dict[str, Any]")))
+
+    def test_optional_subscript(self):
+        self.assertTrue(_rhs_is_type_construct(self._rhs("Optional[int]")))
+
+    def test_list_subscript(self):
+        self.assertTrue(_rhs_is_type_construct(self._rhs("list[int]")))
+
+    def test_union_subscript(self):
+        self.assertTrue(_rhs_is_type_construct(self._rhs("Union[str, int]")))
+
+    #  subscripts that must NOT match (the too-broad bug we fixed) 
+    def test_dict_lookup_not_a_type(self):
+        self.assertFalse(_rhs_is_type_construct(self._rhs('config["key"]')))
+
+    def test_list_index_not_a_type(self):
+        self.assertFalse(_rhs_is_type_construct(self._rhs("not_my_list[0]")))
+
+    def test_arbitrary_subscript_not_a_type(self):
+        self.assertFalse(_rhs_is_type_construct(self._rhs("someWeirdfunky()[0]")))
+
+    #  union with | 
+    def test_bitor_union(self):
+        self.assertTrue(_rhs_is_type_construct(self._rhs("str | int")))
+
+    def test_three_way_bitor_union(self):
+        self.assertTrue(_rhs_is_type_construct(self._rhs("str | int | None")))
+
+    #  functional TypedDict / NamedTuple / NewType 
+    def test_typed_dict_call(self):
+        self.assertTrue(_rhs_is_type_construct(self._rhs('TypedDict("X", {"a": int})')))
+
+    def test_named_tuple_call(self):
+        self.assertTrue(_rhs_is_type_construct(self._rhs('NamedTuple("P", [("x", int)])')))
+
+    def test_new_type_call(self):
+        self.assertTrue(_rhs_is_type_construct(self._rhs('NewType("UserId", int)')))
+
+    #  plain values that must not match 
+    def test_string_literal_not_a_type(self):
+        self.assertFalse(_rhs_is_type_construct(self._rhs('"yelloooo"')))
+
+    def test_function_call_not_a_type(self):
+        self.assertFalse(_rhs_is_type_construct(self._rhs("someones_func()")))
+
+    def test_integer_not_a_type(self):
+        self.assertFalse(_rhs_is_type_construct(self._rhs("42")))
+
+
+class TestExtractTypeDefinitions(unittest.TestCase):
+
+    def _extract(self, code: str):
+        return _extract_type_definitions(code)
+
+    # safe imports go 2 type_imports 
+    def test_typing_import_goes_to_type_imports(self):
+        code = "from typing import Optional\nx = 1"
+        type_imports, type_defs, runtime = self._extract(code)
+        self.assertIn("Optional", type_imports)
+        self.assertNotIn("Optional", runtime)
+
+    def test_stdlib_import_goes_to_type_imports(self):
+        code = "import os\nx = 1"
+        type_imports, _, runtime = self._extract(code)
+        self.assertIn("import os", type_imports)
+        self.assertNotIn("import os", runtime)
+
+    #  third-party import stays in runtime by default 
+    def test_third_party_import_stays_in_runtime(self):
+        code = "import requests\nresult = requests.get('http://x')"
+        type_imports, type_defs, runtime = self._extract(code)
+        self.assertNotIn("requests", type_imports)
+        self.assertIn("requests", runtime)
+
+    #  classes go to type_defs 
+    def test_class_goes_to_type_defs(self):
+        code = "class Foo:\n    x: int = 0\ndef bar(): pass"
+        _, type_defs, runtime = self._extract(code)
+        self.assertIn("class Foo", type_defs)
+        self.assertNotIn("class Foo", runtime)
+
+    def test_function_stays_in_runtime(self):
+        code = "class Foo:\n    pass\ndef my_func(): return 1"
+        _, type_defs, runtime = self._extract(code)
+        self.assertIn("my_func", runtime)
+        self.assertNotIn("my_func", type_defs)
+
+    #  Literal / typing alias assignments go to type_defs 
+    def test_literal_assignment_goes_to_type_defs(self):
+        code = 'Status = Literal["active", "inactive"]\ndef f(): pass'
+        _, type_defs, runtime = self._extract(code)
+        self.assertIn("Status", type_defs)
+        self.assertNotIn("Status", runtime)
+
+    def test_bitor_union_assignment_goes_to_type_defs(self):
+        code = "MyUnion = str | int\ndef f(): pass"
+        _, type_defs, runtime = self._extract(code)
+        self.assertIn("MyUnion", type_defs)
+        self.assertNotIn("MyUnion", runtime)
+
+    #  dict lookup stays in runtime (the narrow-subscript fix) 
+    def test_dict_lookup_stays_in_runtime(self):
+        code = 'DEFAULT = config["timeout"]\ndef f(): pass'
+        _, type_defs, runtime = self._extract(code)
+        self.assertIn("DEFAULT", runtime)
+        self.assertNotIn("DEFAULT", type_defs)
+
+    #  class dependencies are transitively hoisted 
+    def test_class_dep_goes_to_type_defs(self):
+        code = (
+            "from typing import TypedDict\n"
+            "class Inner(TypedDict):\n"
+            "    val: int\n"
+            "class Outer:\n"
+            "    inner: Inner\n"
+            "def f(): pass"
+        )
+        _, type_defs, runtime = self._extract(code)
+        self.assertIn("Inner", type_defs)
+        self.assertIn("Outer", type_defs)
+
+    #  third-party import needed by a class is hoisted (pydantic fix) 
+    def test_third_party_base_class_import_is_hoisted(self):
+        code = (
+            "import pydantic\n"
+            "class MyModel(pydantic.BaseModel):\n"
+            "    name: str\n"
+            "def f(): pass"
+        )
+        type_imports, type_defs, runtime = self._extract(code)
+        self.assertIn("pydantic", type_imports)
+        self.assertNotIn("import pydantic", runtime)
+        self.assertIn("MyModel", type_defs)
+
+    def test_from_import_base_class_is_hoisted(self):
+        code = (
+            "from pydantic import BaseModel\n"
+            "class MyModel(BaseModel):\n"
+            "    name: str\n"
+            "def f(): pass"
+        )
+        type_imports, type_defs, runtime = self._extract(code)
+        self.assertIn("BaseModel", type_imports)
+        self.assertNotIn("BaseModel", runtime)
+
+    #  syntax error falls back to returning all code as runtime 
+    def test_syntax_error_returns_all_as_runtime(self):
+        bad = "def f(\n  broken syntax!!!"
+        type_imports, type_defs, runtime = self._extract(bad)
+        self.assertEqual(type_imports, "")
+        self.assertEqual(type_defs, "")
+        self.assertEqual(runtime, bad)
+
+    #  empty input produces three empty strings 
+    def test_empty_code(self):
+        self.assertEqual(self._extract(""), ("", "", ""))
+
+
+class TestWrapCodeInTryExcept(unittest.TestCase):
+
+    def test_runtime_code_is_wrapped(self):
+        code = "import requests\nresult = requests.get('http://x')"
+        _, wrapped = _wrap_code_in_try_except("myFunc", code)
+        self.assertIn("try:", wrapped)
+        self.assertIn("except ImportError", wrapped)
+        self.assertIn("myFunc", wrapped)
+
+    def test_type_defs_go_to_module_scope(self):
+        code = "from typing import Optional\nclass Foo:\n    x: Optional[int] = None\ndef f(): pass"
+        module_scope, wrapped = _wrap_code_in_try_except("f", code)
+        self.assertIn("Optional", module_scope)
+        self.assertIn("Foo", module_scope)
+        self.assertNotIn("class Foo", wrapped)
+
+    def test_empty_runtime_emits_pass(self):
+        # Code that is entirely type definitions — runtime body should be 'pass'
+        code = "from typing import Optional\nclass Foo:\n    x: Optional[int] = None"
+        _, wrapped = _wrap_code_in_try_except("myFunc", code)
+        self.assertIn("pass", wrapped)
+        self.assertIn("try:", wrapped)
+
+    def test_whitespace_only_runtime_emits_pass(self):
+        code = "from typing import List\n"
+        _, wrapped = _wrap_code_in_try_except("myFunc", code)
+        self.assertIn("pass", wrapped)
+
+    def test_warning_message_contains_function_name(self):
+        code = "x = 1"
+        _, wrapped = _wrap_code_in_try_except("specialFunc", code)
+        self.assertIn("specialFunc", wrapped)
+        self.assertIn("logger.warning", wrapped)
+
+    def test_multiline_runtime_is_indented(self):
+        code = "import requests\na = 1\nb = 2"
+        _, wrapped = _wrap_code_in_try_except("f", code)
+        # Every line inside the try block should be indented
+        try_block = wrapped.split("try:\n")[1].split("\nexcept")[0]
+        for line in try_block.splitlines():
+            if line.strip():
+                self.assertTrue(line.startswith("    "), repr(line))
+
+
+class TestRenderClientFunction(unittest.TestCase):
+    _SIMPLE_CODE = (
+        "import requests\n"
+        "def execute(url: str) -> str:\n"
+        "    return requests.get(url).text\n"
+    )
+    _SIMPLE_ARGS = [{"name": "url", "required": True, "type": {"kind": "string"}}]
+    _SIMPLE_RETURN = {"kind": "string"}
+
+    def test_returns_three_parts(self):
+        result = render_client_function("myFunc", self._SIMPLE_CODE, self._SIMPLE_ARGS, self._SIMPLE_RETURN)
+        self.assertEqual(len(result), 3)
+
+    def test_module_scope_types_string(self):
+        module_scope, _, _ = render_client_function("myFunc", self._SIMPLE_CODE, self._SIMPLE_ARGS, self._SIMPLE_RETURN)
+        self.assertIsInstance(module_scope, str)
+
+    def test_wrapped_runtime_contains_try(self):
+        _, wrapped, _ = render_client_function("myFunc", self._SIMPLE_CODE, self._SIMPLE_ARGS, self._SIMPLE_RETURN)
+        self.assertIn("try:", wrapped)
+
+    def test_func_type_defs_contains_return_type(self):
+        _, _, func_type_defs = render_client_function("myFunc", self._SIMPLE_CODE, self._SIMPLE_ARGS, self._SIMPLE_RETURN)
+        self.assertIsInstance(func_type_defs, str)
+        self.assertGreater(len(func_type_defs), 0)
+
+    def test_pydantic_model_import_hoisted_to_module_scope(self):
+        code = (
+            "import pydantic\n"
+            "class Item(pydantic.BaseModel):\n"
+            "    name: str\n"
+            "def execute() -> Item:\n"
+            "    return Item(name='x')\n"
+        )
+        module_scope, wrapped, _ = render_client_function("execute", code, [], {"kind": "object"})
+        self.assertIn("pydantic", module_scope)
+        self.assertIn("Item", module_scope)
+        self.assertNotIn("class Item", wrapped)
+
+    def test_type_only_code_produces_pass_in_try(self):
+        code = (
+            "from typing import Optional\n"
+            "class Foo:\n"
+            "    x: Optional[int] = None\n"
+        )
+        _, wrapped, _ = render_client_function("myFunc", code, [], {"kind": "null"})
+        self.assertIn("pass", wrapped)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -45,9 +45,7 @@ class TestImportBoundNames(unittest.TestCase):
         self.assertEqual(_import_bound_names(_parse_stmt("x = 555555")), set())
 
 
-# 
 # _is_safe_import
-# 
 
 class TestIsSafeImport(unittest.TestCase):
     def test_typing_is_safe(self):
@@ -69,9 +67,7 @@ class TestIsSafeImport(unittest.TestCase):
         self.assertFalse(_is_safe_import(_parse_stmt("x = 666")))
 
 
-# 
 # _rhs_is_type_construct
-# 
 
 class TestRhsIsTypeConstruct(unittest.TestCase):
     def _rhs(self, src: str) -> ast.expr:
@@ -120,7 +116,7 @@ class TestRhsIsTypeConstruct(unittest.TestCase):
     def test_new_type_call(self):
         self.assertTrue(_rhs_is_type_construct(self._rhs('NewType("UserId", int)')))
 
-    #  plain values that must not match 
+    #  plain values that must not match
     def test_string_literal_not_a_type(self):
         self.assertFalse(_rhs_is_type_construct(self._rhs('"yelloooo"')))
 
@@ -129,6 +125,233 @@ class TestRhsIsTypeConstruct(unittest.TestCase):
 
     def test_integer_not_a_type(self):
         self.assertFalse(_rhs_is_type_construct(self._rhs("42")))
+
+    # attribute-qualified subscripts (typing.X[...]) 
+    # node.value is ast.Attribute, not ast.Name — the Name guard silently
+    # rejects these, so fully-qualified generics are never hoisted to module scope.
+
+    def test_attribute_optional_is_type(self):
+        # typing.Optional[int] — value is Attribute, currently returns False
+        self.assertTrue(_rhs_is_type_construct(self._rhs("typing.Optional[int]")))
+
+    def test_attribute_dict_is_type(self):
+        # typing.Dict[str, Any] — same miss
+        self.assertTrue(_rhs_is_type_construct(self._rhs("typing.Dict[str, Any]")))
+
+    def test_attribute_union_is_type(self):
+        # typing.Union[str, int]
+        self.assertTrue(_rhs_is_type_construct(self._rhs("typing.Union[str, int]")))
+
+    # TypeVar / ParamSpec / TypeVarTuple functional forms
+    # These are missing from the ('TypedDict', 'NamedTuple', 'NewType') allowlist,
+    # so TypeVar assignments are treated as runtime values and never hoisted.
+
+    def test_typevar_call_is_type(self):
+        # T = TypeVar("T") — currently returns False
+        self.assertTrue(_rhs_is_type_construct(self._rhs('TypeVar("T")')))
+
+    def test_typevar_with_bound_is_type(self):
+        # T = TypeVar("T", bound=str)
+        self.assertTrue(_rhs_is_type_construct(self._rhs('TypeVar("T", bound=str)')))
+
+    def test_paramspec_call_is_type(self):
+        # P = ParamSpec("P") — currently returns False
+        self.assertTrue(_rhs_is_type_construct(self._rhs('ParamSpec("P")')))
+
+    def test_typevartuple_call_is_type(self):
+        # Ts = TypeVarTuple("Ts") — currently returns False
+        self.assertTrue(_rhs_is_type_construct(self._rhs('TypeVarTuple("Ts")')))
+
+    # attribute-qualified functional forms (typing.TypedDict / typing.NewType)
+    # node.func is ast.Attribute — the isinstance(node.func, ast.Name) guard rejects these.
+
+    def test_attribute_typed_dict_call_is_type(self):
+        # typing.TypedDict("X", {"a": int}) — func is Attribute, currently False
+        self.assertTrue(_rhs_is_type_construct(self._rhs('typing.TypedDict("X", {"a": int})')))
+
+    def test_attribute_new_type_call_is_type(self):
+        # typing.NewType("UserId", int) — same miss
+        self.assertTrue(_rhs_is_type_construct(self._rhs('typing.NewType("UserId", int)')))
+
+
+# Exhaustive parametric coverage of _rhs_is_type_construct
+
+_TRUE_CASES = [
+    # Subscript — bare name (original set)
+    ('Literal["a"]',              ast.Subscript),
+    ('Dict[str, Any]',            ast.Subscript),
+    ('Optional[int]',             ast.Subscript),
+    ('list[int]',                 ast.Subscript),
+    ('Union[str, int]',           ast.Subscript),
+    # Subscript — qualified name (typing_extensions.X[...])
+    ('typing_extensions.Optional[int]',   ast.Subscript),
+    ('typing_extensions.Dict[str, Any]',  ast.Subscript),
+    ('typing_extensions.Union[str, int]', ast.Subscript),
+    # Subscript — full typing_extensions.__all__ subscriptable names
+    ('ClassVar[int]',             ast.Subscript),
+    ('Final[int]',                ast.Subscript),
+    ('Annotated[int, ...]',       ast.Subscript),
+    ('Required[int]',             ast.Subscript),
+    ('NotRequired[int]',          ast.Subscript),
+    ('ReadOnly[int]',             ast.Subscript),
+    ('Type[int]',                 ast.Subscript),
+    ('Concatenate[int, ...]',     ast.Subscript),
+    ('Unpack[Ts]',                ast.Subscript),
+    ('TypeGuard[int]',            ast.Subscript),
+    ('TypeIs[int]',               ast.Subscript),
+    ('LiteralString[str]',        ast.Subscript),  # used as annotation
+    ('Self[int]',                 ast.Subscript),
+    ('Never[int]',                ast.Subscript),
+    ('NoReturn[int]',             ast.Subscript),
+    ('Callable[[int], str]',      ast.Subscript),
+    ('Awaitable[int]',            ast.Subscript),
+    ('Coroutine[int, int, int]',  ast.Subscript),
+    ('AsyncIterable[int]',        ast.Subscript),
+    ('AsyncIterator[int]',        ast.Subscript),
+    ('AsyncGenerator[int, int]',  ast.Subscript),
+    ('AsyncContextManager[int]',  ast.Subscript),
+    ('Iterable[int]',             ast.Subscript),
+    ('Iterator[int]',             ast.Subscript),
+    ('Generator[int, int, int]',  ast.Subscript),
+    ('ContextManager[int]',       ast.Subscript),
+    ('Container[int]',            ast.Subscript),
+    ('Collection[int]',           ast.Subscript),
+    ('Reversible[int]',           ast.Subscript),
+    ('Mapping[str, int]',         ast.Subscript),
+    ('MutableMapping[str, int]',  ast.Subscript),
+    ('MappingView[str]',          ast.Subscript),
+    ('KeysView[str]',             ast.Subscript),
+    ('ItemsView[str, int]',       ast.Subscript),
+    ('ValuesView[int]',           ast.Subscript),
+    ('Sequence[int]',             ast.Subscript),
+    ('MutableSequence[int]',      ast.Subscript),
+    ('MutableSet[int]',           ast.Subscript),
+    ('AbstractSet[int]',          ast.Subscript),
+    ('IO[str]',                   ast.Subscript),
+    ('Match[str]',                ast.Subscript),
+    ('Pattern[str]',              ast.Subscript),
+    ('FrozenSet[int]',            ast.Subscript),
+    ('Tuple[int, str]',           ast.Subscript),
+    ('Set[int]',                  ast.Subscript),
+    ('DefaultDict[str, int]',     ast.Subscript),
+    ('OrderedDict[str, int]',     ast.Subscript),
+    ('Counter[str]',              ast.Subscript),
+    ('Deque[int]',                ast.Subscript),
+    ('ChainMap[str, int]',        ast.Subscript),
+    ('Generic[T]',                ast.Subscript),
+    ('Protocol[T]',               ast.Subscript),
+    ('AnyStr[str]',               ast.Subscript),
+    # BinOp with | — all leaves must be unambiguously type-like
+    ('str | int',                         ast.BinOp),
+    ('str | int | None',                  ast.BinOp),
+    ('Optional[str] | None',              ast.BinOp),
+    ('List[int] | None',                  ast.BinOp),
+    # typing-module attributes are valid union leaves
+    ('typing.Optional | None',            ast.BinOp),
+    ('typing_extensions.Optional | None', ast.BinOp),
+    # typing subscript on either side
+    ('typing.Optional[str] | None',       ast.BinOp),
+    # Call — bare name
+    ('TypedDict("X", {})',           ast.Call),
+    ('NamedTuple("P", [])',          ast.Call),
+    ('NewType("U", int)',            ast.Call),
+    ('TypeVar("T")',                 ast.Call),
+    ('TypeVar("T", bound=str)',      ast.Call),
+    ('ParamSpec("P")',               ast.Call),
+    ('TypeVarTuple("Ts")',           ast.Call),
+    ('TypeAliasType("MyAlias", int)', ast.Call),
+    # Call — qualified name (typing_extensions.X(...))
+    ('typing_extensions.TypedDict("X", {})', ast.Call),
+    ('typing_extensions.NewType("U", int)',  ast.Call),
+    ('typing_extensions.TypeVar("T")',       ast.Call),
+]
+
+_FALSE_CASES = [
+    ('config["key"]',    ast.Subscript),   # dict lookup
+    ('my_list[0]',       ast.Subscript),   # index
+    ('foo()',            ast.Call),         # unknown call
+    ('random_func("X")', ast.Call),        # unknown functional
+    ('"hello"',          ast.Constant),
+    ('42',               ast.Constant),
+    ('x',                ast.Name),
+    ('[1, 2]',           ast.List),
+    ('(1, 2)',           ast.Tuple),
+    ('{1, 2}',           ast.Set),
+    ('x if y else z',    ast.IfExp),
+    ('lambda: None',     ast.Lambda),
+    ('x and y',          ast.BoolOp),
+    ('-x',               ast.UnaryOp),
+    ('x < y',            ast.Compare),
+    ('{1: 2}',           ast.Dict),
+    # bitwise OR on non-type operands must NOT be hoisted as a type alias
+    ('1 | 2',                  ast.BinOp),   # integer literals
+    ('0xFF | 0x01',            ast.BinOp),   # hex literals
+    ('"a" | "b"',              ast.BinOp),   # string literals
+    # non-typing module attributes rejected (FP-1 / FP-5)
+    ('os.O_RDONLY | int',      ast.BinOp),   # stdlib flag + type anchor
+    ('mod.SomeFlag | str',     ast.BinOp),   # arbitrary attribute + type anchor
+    # named constants rejected even when mixed with a primitive (B-1)
+    ('READ | int',             ast.BinOp),   # READ not in _BUILTIN_TYPE_NAMES
+    # runtime subscript in union rejected (B-2)
+    ('my_list[0] | None',      ast.BinOp),   # my_list not a typing name
+    # two arbitrary class names with no known-type leaf (accepted false negative)
+    ('MyClass | OtherClass',   ast.BinOp),
+    ('[x for x in y]',   ast.ListComp),
+    ('{x for x in y}',   ast.SetComp),
+    ('{x: x for x in y}', ast.DictComp),
+    ('(x for x in y)',   ast.GeneratorExp),
+    ('os.path',          ast.Attribute),   # bare attribute access, not a type construct
+]
+
+# Node types that cannot appear as the RHS of a plain assignment statement
+_CANT_BE_RHS = frozenset(filter(None, [
+    ast.Starred,      # *x — only in unpacking targets
+    ast.Slice,        # a[1:2] — slice object, not standalone
+    ast.Await,        # await x — async context only
+    ast.Yield,        # yield x — function body only
+    ast.YieldFrom,    # yield from x — function body only
+    ast.NamedExpr,    # (x := y) — not a sane type alias RHS
+    # f-string / template internals (3.12+)
+    getattr(ast, 'FormattedValue', None),
+    getattr(ast, 'JoinedStr', None),
+    getattr(ast, 'Interpolation', None),
+    getattr(ast, 'TemplateStr', None),
+]))
+
+
+class TestRhsIsTypeConstructExhaustive(unittest.TestCase):
+
+    @staticmethod
+    def _rhs(src: str) -> ast.expr:
+        return ast.parse(src).body[0].value  # type: ignore[attr-defined]
+
+    def test_true_cases(self):
+        for src, expected_type in _TRUE_CASES:
+            with self.subTest(src=src):
+                node = self._rhs(src)
+                self.assertIsInstance(node, expected_type,
+                    f"fixture parses to wrong node type for {src!r}")
+                self.assertTrue(_rhs_is_type_construct(node),
+                    f"expected True for {src!r}")
+
+    def test_false_cases(self):
+        for src, expected_type in _FALSE_CASES:
+            with self.subTest(src=src):
+                node = self._rhs(src)
+                self.assertIsInstance(node, expected_type,
+                    f"fixture parses to wrong node type for {src!r}")
+                self.assertFalse(_rhs_is_type_construct(node),
+                    f"expected False for {src!r}")
+
+    def test_all_expr_subtypes_are_classified(self):
+        """Fail if a new ast.expr subclass appears that has no row in either table."""
+        covered = {type(self._rhs(src)) for src, _ in _TRUE_CASES + _FALSE_CASES}
+        for cls in ast.expr.__subclasses__():
+            if cls in _CANT_BE_RHS:
+                continue
+            with self.subTest(cls=cls.__name__):
+                self.assertIn(cls, covered,
+                    f"{cls.__name__} has no row in _TRUE_CASES or _FALSE_CASES — add one")
 
 
 class TestExtractTypeDefinitions(unittest.TestCase):
@@ -227,7 +450,56 @@ class TestExtractTypeDefinitions(unittest.TestCase):
         self.assertIn("BaseModel", type_imports)
         self.assertNotIn("BaseModel", runtime)
 
-    #  syntax error falls back to returning all code as runtime 
+    #  multi-target chained assignments (X = Y = List[int])
+    def test_chained_assignment_both_targets_hoisted(self):
+        code = "X = Y = List[int]\ndef f(): pass"
+        _, type_defs, runtime = self._extract(code)
+        self.assertIn("X", type_defs)
+        self.assertIn("Y", type_defs)
+        self.assertNotIn("X", runtime)
+        self.assertNotIn("Y", runtime)
+
+    #  nested class free variables are transitively hoisted
+    def test_nested_class_dep_is_hoisted(self):
+        # ENCODER is only referenced inside Inner (nested in Outer).
+        # Without the recursive symtable walk it would be missed.
+        code = (
+            "import json\n"
+            "ENCODER = json.JSONEncoder\n"
+            "class Outer:\n"
+            "    class Inner:\n"
+            "        encoder = ENCODER\n"
+            "def f(): pass\n"
+        )
+        _, type_defs, runtime = self._extract(code)
+        self.assertIn("ENCODER", type_defs)
+        self.assertNotIn("ENCODER", runtime)
+
+    #  FP-4: only the first bare string after a class is hoisted, not a cascade
+    def test_only_first_docstring_after_class_is_hoisted(self):
+        code = (
+            "class Foo:\n"
+            "    pass\n"
+            '"first"\n'
+            '"second"\n'
+            '"third"\n'
+            "def f(): pass\n"
+        )
+        _, type_defs, runtime = self._extract(code)
+        self.assertIn('"first"', type_defs)
+        self.assertNotIn('"second"', type_defs)
+        self.assertNotIn('"third"', type_defs)
+        self.assertIn('"second"', runtime)
+        self.assertIn('"third"', runtime)
+
+    #  FP-5: CRLF line endings must not corrupt indentation
+    def test_crlf_line_endings_normalized(self):
+        code = "import requests\r\nresult = requests.get('http://x')\r\n"
+        type_imports, type_defs, runtime = self._extract(code)
+        for part in (type_imports, type_defs, runtime):
+            self.assertNotIn('\r', part)
+
+    #  syntax error falls back to returning all code as runtime
     def test_syntax_error_returns_all_as_runtime(self):
         bad = "def f(\n  broken syntax!!!"
         type_imports, type_defs, runtime = self._extract(bad)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -427,7 +427,9 @@ class TestExtractTypeDefinitions(unittest.TestCase):
         self.assertIn("Outer", type_defs)
 
     #  third-party import needed by a class is hoisted (pydantic fix) 
-    def test_third_party_base_class_import_is_hoisted(self):
+    def test_third_party_base_class_stays_in_runtime(self):
+        # Third-party imports are not safe to hoist (missing dep crashes the module).
+        # The class and its import both stay in the try/except runtime block.
         code = (
             "import pydantic\n"
             "class MyModel(pydantic.BaseModel):\n"
@@ -435,11 +437,13 @@ class TestExtractTypeDefinitions(unittest.TestCase):
             "def f(): pass"
         )
         type_imports, type_defs, runtime = self._extract(code)
-        self.assertIn("pydantic", type_imports)
-        self.assertNotIn("import pydantic", runtime)
-        self.assertIn("MyModel", type_defs)
+        self.assertNotIn("pydantic", type_imports)
+        self.assertIn("pydantic", runtime)
+        self.assertNotIn("MyModel", type_defs)
+        self.assertIn("MyModel", runtime)
 
-    def test_from_import_base_class_is_hoisted(self):
+    def test_from_import_base_class_stays_in_runtime(self):
+        # Same as above for from-import style.
         code = (
             "from pydantic import BaseModel\n"
             "class MyModel(BaseModel):\n"
@@ -447,8 +451,8 @@ class TestExtractTypeDefinitions(unittest.TestCase):
             "def f(): pass"
         )
         type_imports, type_defs, runtime = self._extract(code)
-        self.assertIn("BaseModel", type_imports)
-        self.assertNotIn("BaseModel", runtime)
+        self.assertNotIn("BaseModel", type_imports)
+        self.assertIn("BaseModel", runtime)
 
     #  multi-target chained assignments (X = Y = List[int])
     def test_chained_assignment_both_targets_hoisted(self):
@@ -582,7 +586,9 @@ class TestRenderClientFunction(unittest.TestCase):
         self.assertIsInstance(func_type_defs, str)
         self.assertGreater(len(func_type_defs), 0)
 
-    def test_pydantic_model_import_hoisted_to_module_scope(self):
+    def test_pydantic_model_stays_in_try_block(self):
+        # Third-party imports are not safe to hoist — pydantic and Item both stay
+        # inside the try/except so a missing dep only silences that function.
         code = (
             "import pydantic\n"
             "class Item(pydantic.BaseModel):\n"
@@ -591,9 +597,9 @@ class TestRenderClientFunction(unittest.TestCase):
             "    return Item(name='x')\n"
         )
         module_scope, wrapped, _ = render_client_function("execute", code, [], {"kind": "object"})
-        self.assertIn("pydantic", module_scope)
-        self.assertIn("Item", module_scope)
-        self.assertNotIn("class Item", wrapped)
+        self.assertNotIn("pydantic", module_scope)
+        self.assertNotIn("Item", module_scope)
+        self.assertIn("class Item", wrapped)
 
     def test_type_only_code_produces_pass_in_try(self):
         code = (

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -115,7 +115,7 @@ class T(unittest.TestCase):
 
     def test_render_spec_no_function_data(self):
         """Test that render_spec handles specs with no function data gracefully"""
-        func_str, func_type_defs = render_spec(NO_TYPES_SPEC)
+        _, func_str, func_type_defs = render_spec(NO_TYPES_SPEC)
         
         # Should generate a function even without function data
         self.assertIsNotNone(func_str)
@@ -125,7 +125,7 @@ class T(unittest.TestCase):
 
     def test_render_spec_minimal_function_data(self):
         """Test that render_spec handles specs with minimal function data"""
-        func_str, func_type_defs = render_spec(MINIMAL_FUNCTION_SPEC)
+        _, func_str, func_type_defs = render_spec(MINIMAL_FUNCTION_SPEC)
         
         # Should generate a function with fallback types
         self.assertIsNotNone(func_str)

--- a/tests/test_rendered_spec.py
+++ b/tests/test_rendered_spec.py
@@ -1,5 +1,5 @@
 import unittest
-from mock import patch, Mock
+from unittest.mock import patch, Mock
 
 from polyapi.rendered_spec import get_and_update_rendered_spec
 


### PR DESCRIPTION
[#5933](https://github.com/polyapi/poly-alpha/issues/5933)

Okay this is a big change but this makes it possible to not define types in CFX 3X. Tested against actual GHA CFX - all ok! Will work in server func logic similarly once this gets changes suggested and resolved! 

