### PR TITLE
5998 dataclasses support for varis

### DIFF
--- a/polyapi/utils.py
+++ b/polyapi/utils.py
@@ -14,9 +14,32 @@ from polyapi.schema import (
 )
 
 
+class DotDict(dict):
+    """Dict with recursive dot-notation attribute access.
+
+    Supports both dict-style (d["key"]) and attribute-style (d.key) access.
+    Nested dicts are automatically wrapped on access.
+    """
+    def __getattr__(self, key: str):
+        try:
+            val = self[key]
+            return DotDict(val) if isinstance(val, dict) else val
+        except KeyError:
+            raise AttributeError(f"'{type(self).__name__}' object has no attribute '{key}'")
+
+    def __setattr__(self, key: str, value):
+        self[key] = value
+
+    def __delattr__(self, key: str):
+        try:
+            del self[key]
+        except KeyError:
+            raise AttributeError(key)
+
+
 # this string should be in every __init__ file.
 # it contains all the imports needed for the function or variable code to run
-CODE_IMPORTS = "from typing import List, Dict, Any, Optional, Callable\nfrom typing_extensions import TypedDict, NotRequired\nimport logging\nimport requests\nimport socketio  # type: ignore\nfrom polyapi.config import get_api_key_and_url, get_direct_execute_config\nfrom polyapi.execute import execute, execute_async, execute_post, execute_post_async, variable_get, variable_get_async, variable_update, variable_update_async, direct_execute, direct_execute_async\n\n"
+CODE_IMPORTS = "from typing import List, Dict, Any, Optional, Callable\nfrom typing_extensions import TypedDict, NotRequired\nimport json\nimport logging\nimport requests\nimport socketio  # type: ignore\nfrom polyapi.config import get_api_key_and_url, get_direct_execute_config\nfrom polyapi.execute import execute, execute_async, execute_post, execute_post_async, variable_get, variable_get_async, variable_update, variable_update_async, direct_execute, direct_execute_async\nfrom polyapi.utils import DotDict\n\n"
 
 
 def init_the_init(full_path: str, code_imports: Optional[str] = None) -> None:

--- a/polyapi/variables.py
+++ b/polyapi/variables.py
@@ -1,4 +1,6 @@
 import os
+import re
+import keyword
 import logging
 import tempfile
 import shutil
@@ -27,12 +29,12 @@ GET_PARSED_TEMPLATE = """
     @staticmethod
     def get_parsed() -> "{parsed_type}":
         resp = variable_get("{variable_id}")
-        return {parsed_type}(**json.loads(resp.text))
+        return {parsed_type}.from_dict(json.loads(resp.text))
 
     @staticmethod
     async def get_parsed_async() -> "{parsed_type}":
         resp = await variable_get_async("{variable_id}")
-        return {parsed_type}(**json.loads(resp.text))
+        return {parsed_type}.from_dict(json.loads(resp.text))
 """
 
 
@@ -110,6 +112,17 @@ def generate_variables(variables: List[VariableSpecDto]):
             logging.warning(f"  - {failed_var}")
 
 
+def _sanitize_field_name(name: str) -> str:
+    sanitized = re.sub(r'[^a-zA-Z0-9_]', '_', name)
+    if sanitized and sanitized[0].isdigit():
+        sanitized = '_' + sanitized
+    if not sanitized:
+        sanitized = 'field_'
+    if keyword.iskeyword(sanitized):
+        sanitized += '_'
+    return sanitized
+
+
 def _schema_to_dataclass(variable_name: str, schema: dict) -> tuple:
     """Generate a @dataclass from a variable's JSON schema properties.
 
@@ -124,18 +137,31 @@ def _schema_to_dataclass(variable_name: str, schema: dict) -> tuple:
 
     _TYPE_MAP = {"string": "str", "integer": "int", "number": "float", "boolean": "bool", "object": "Dict", "array": "List"}
     req_fields, opt_fields = [], []
+    # (json_key, python_field_name) pairs for from_dict
+    field_map = []
     for prop, prop_schema in properties.items():
         py_type = _TYPE_MAP.get(prop_schema.get("type", "string"), "Any")
+        safe = _sanitize_field_name(prop)
+        field_map.append((prop, safe))
         if prop in required:
-            req_fields.append(f"    {prop}: {py_type}")
+            req_fields.append(f"    {safe}: {py_type}")
         else:
-            opt_fields.append(f"    {prop}: Optional[{py_type}] = field(default=None)")
+            opt_fields.append(f"    {safe}: Optional[{py_type}] = field(default=None)")
+
+    from_dict_args = ", ".join(f'{safe}=d.get("{key}")' for key, safe in field_map)
+    from_dict_lines = [
+        "",
+        "    @classmethod",
+        "    def from_dict(cls, d):",
+        f"        return cls({from_dict_args})",
+    ]
 
     lines = ["from dataclasses import dataclass, field", "", "@dataclass", f"class {class_name}:"]
     lines.extend(req_fields)
     lines.extend(opt_fields)
     if not req_fields and not opt_fields:
         lines.append("    pass")
+    lines.extend(from_dict_lines)
     return class_name, "\n".join(lines)
 
 

--- a/polyapi/variables.py
+++ b/polyapi/variables.py
@@ -1,6 +1,6 @@
-import os
-import re
 import keyword
+import re
+import os
 import logging
 import tempfile
 import shutil
@@ -24,17 +24,31 @@ GET_TEMPLATE = """
         return resp.text
 """
 
-# Appended to GET_TEMPLATE for object variables; opt-in parsed access with dot notation
+# Appended to GET_TEMPLATE for object variables with no schema; dict + dot access via DotDict
 GET_PARSED_TEMPLATE = """
+    @staticmethod
+    def get_parsed() -> "DotDict":
+        resp = variable_get("{variable_id}")
+        return DotDict(json.loads(resp.text))
+
+    @staticmethod
+    async def get_parsed_async() -> "DotDict":
+        resp = await variable_get_async("{variable_id}")
+        return DotDict(json.loads(resp.text))
+"""
+
+# Appended to GET_TEMPLATE for schema-backed object variables; uses _from_json to handle
+# field name sanitization and provides both dot and dict access via __getitem__
+GET_PARSED_SCHEMA_TEMPLATE = """
     @staticmethod
     def get_parsed() -> "{parsed_type}":
         resp = variable_get("{variable_id}")
-        return {parsed_type}.from_dict(json.loads(resp.text))
+        return {parsed_type}._from_json(json.loads(resp.text))
 
     @staticmethod
     async def get_parsed_async() -> "{parsed_type}":
         resp = await variable_get_async("{variable_id}")
-        return {parsed_type}.from_dict(json.loads(resp.text))
+        return {parsed_type}._from_json(json.loads(resp.text))
 """
 
 
@@ -116,11 +130,9 @@ def _sanitize_field_name(name: str) -> str:
     sanitized = re.sub(r'[^a-zA-Z0-9_]', '_', name)
     if sanitized and sanitized[0].isdigit():
         sanitized = '_' + sanitized
-    if not sanitized:
-        sanitized = 'field_'
     if keyword.iskeyword(sanitized):
-        sanitized += '_'
-    return sanitized
+        sanitized = sanitized + '_'
+    return sanitized or '_field'
 
 
 def _schema_to_dataclass(variable_name: str, schema: dict) -> tuple:
@@ -136,50 +148,39 @@ def _schema_to_dataclass(variable_name: str, schema: dict) -> tuple:
     class_name = "".join(w.capitalize() for w in variable_name.replace("-", "_").split("_"))
 
     _TYPE_MAP = {"string": "str", "integer": "int", "number": "float", "boolean": "bool", "object": "Dict", "array": "List"}
+
+    # Map each JSON key to a valid Python identifier; track remapped keys for runtime use
+    all_names = {prop: _sanitize_field_name(prop) for prop in properties}
+    field_map = {orig: san for orig, san in all_names.items() if orig != san}
+
     req_fields, opt_fields = [], []
-    # (json_key, python_field_name) pairs for from_dict
-    field_map = []
     for prop, prop_schema in properties.items():
         py_type = _TYPE_MAP.get(prop_schema.get("type", "string"), "Any")
-        safe = _sanitize_field_name(prop)
-        field_map.append((prop, safe))
+        py_attr = all_names[prop]
         if prop in required:
-            req_fields.append(f"    {safe}: {py_type}")
+            req_fields.append(f"    {py_attr}: {py_type}")
         else:
-            opt_fields.append(f"    {safe}: Optional[{py_type}] = field(default=None)")
-
-    from_dict_args = ", ".join(f'{safe}=d.get("{key}")' for key, safe in field_map)
-    from_dict_lines = [
-        "",
-        "    @classmethod",
-        "    def from_dict(cls, d):",
-        f"        return cls({from_dict_args})",
-    ]
-
-    # Support dict-style access (parsed["key"] and parsed["first-name"] → parsed.first_name)
-    # so schema-backed Varis keep the same fallback contract as DotDict.
-    key_map_entries = ", ".join(f'"{key}": "{safe}"' for key, safe in field_map if key != safe)
-    if key_map_entries:
-        getitem_lines = [
-            "",
-            "    def __getitem__(self, key):",
-            f"        _key_map = {{{key_map_entries}}}",
-            "        return getattr(self, _key_map.get(key, key))",
-        ]
-    else:
-        getitem_lines = [
-            "",
-            "    def __getitem__(self, key):",
-            "        return getattr(self, key)",
-        ]
+            opt_fields.append(f"    {py_attr}: Optional[{py_type}] = field(default=None)")
 
     lines = ["from dataclasses import dataclass, field", "", "@dataclass", f"class {class_name}:"]
     lines.extend(req_fields)
     lines.extend(opt_fields)
     if not req_fields and not opt_fields:
         lines.append("    pass")
-    lines.extend(from_dict_lines)
-    lines.extend(getitem_lines)
+
+    map_repr = repr(field_map)
+    lines.extend([
+        "",
+        "    @classmethod",
+        f"    def _from_json(cls, data: dict) -> \"{class_name}\":",
+        f"        _map = {map_repr}",
+        "        return cls(**{_map.get(k, k): v for k, v in data.items()})",
+        "",
+        "    def __getitem__(self, key: str):",
+        f"        _map = {map_repr}",
+        "        return getattr(self, _map.get(key, key))",
+    ])
+
     return class_name, "\n".join(lines)
 
 
@@ -198,7 +199,10 @@ def render_variable(variable: VariableSpecDto):
     else:
         get_method = GET_TEMPLATE.format(variable_id=variable["id"], variable_type=variable_type)
         if is_object:
-            get_method += GET_PARSED_TEMPLATE.format(variable_id=variable["id"], parsed_type=parsed_type)
+            if class_name:
+                get_method += GET_PARSED_SCHEMA_TEMPLATE.format(variable_id=variable["id"], parsed_type=parsed_type)
+            else:
+                get_method += GET_PARSED_TEMPLATE.format(variable_id=variable["id"])
 
     return TEMPLATE.format(
         variable_name=variable["name"],

--- a/polyapi/variables.py
+++ b/polyapi/variables.py
@@ -22,10 +22,23 @@ GET_TEMPLATE = """
         return resp.text
 """
 
+# Appended to GET_TEMPLATE for object variables; opt-in parsed access with dot notation
+GET_PARSED_TEMPLATE = """
+    @staticmethod
+    def get_parsed() -> "{parsed_type}":
+        resp = variable_get("{variable_id}")
+        return {parsed_type}(**json.loads(resp.text))
+
+    @staticmethod
+    async def get_parsed_async() -> "{parsed_type}":
+        resp = await variable_get_async("{variable_id}")
+        return {parsed_type}(**json.loads(resp.text))
+"""
+
 
 TEMPLATE = """
 from polyapi.poly.client_id import client_id
-
+{type_class}
 
 class {variable_name}:{get_method}
     variable_id = "{variable_id}"
@@ -97,21 +110,58 @@ def generate_variables(variables: List[VariableSpecDto]):
             logging.warning(f"  - {failed_var}")
 
 
+def _schema_to_dataclass(variable_name: str, schema: dict) -> tuple:
+    """Generate a @dataclass from a variable's JSON schema properties.
+
+    Returns (class_name, class_code), or (None, None) if schema has no properties.
+    """
+    properties = schema.get("properties", {})
+    if not properties:
+        return None, None
+
+    required = set(schema.get("required", []))
+    class_name = "".join(w.capitalize() for w in variable_name.replace("-", "_").split("_"))
+
+    _TYPE_MAP = {"string": "str", "integer": "int", "number": "float", "boolean": "bool", "object": "Dict", "array": "List"}
+    req_fields, opt_fields = [], []
+    for prop, prop_schema in properties.items():
+        py_type = _TYPE_MAP.get(prop_schema.get("type", "string"), "Any")
+        if prop in required:
+            req_fields.append(f"    {prop}: {py_type}")
+        else:
+            opt_fields.append(f"    {prop}: Optional[{py_type}] = field(default=None)")
+
+    lines = ["from dataclasses import dataclass, field", "", "@dataclass", f"class {class_name}:"]
+    lines.extend(req_fields)
+    lines.extend(opt_fields)
+    if not req_fields and not opt_fields:
+        lines.append("    pass")
+    return class_name, "\n".join(lines)
+
+
 def render_variable(variable: VariableSpecDto):
     variable_type = _get_variable_type(variable["variable"]["valueType"])
-    # Only include get() method if secrecy is not SECRET
-    get_method = (
-        ""
-        if variable["variable"]["secrecy"] == "SECRET"
-        else GET_TEMPLATE.format(
-            variable_id=variable["id"], variable_type=variable_type
-        )
-    )
+    is_secret = variable["variable"]["secrecy"] == "SECRET"
+    is_object = variable_type in ("Dict", "Any")
+
+    schema = variable["variable"]["valueType"].get("schema", {})
+    class_name, type_class_code = _schema_to_dataclass(variable["name"], schema) if schema else (None, None)
+    parsed_type = class_name or "DotDict"
+    type_class = f"\n{type_class_code}\n" if type_class_code else ""
+
+    if is_secret:
+        get_method = ""
+    else:
+        get_method = GET_TEMPLATE.format(variable_id=variable["id"], variable_type=variable_type)
+        if is_object:
+            get_method += GET_PARSED_TEMPLATE.format(variable_id=variable["id"], parsed_type=parsed_type)
+
     return TEMPLATE.format(
         variable_name=variable["name"],
         variable_id=variable["id"],
         variable_type=variable_type,
         get_method=get_method,
+        type_class=type_class,
     )
 
 

--- a/polyapi/variables.py
+++ b/polyapi/variables.py
@@ -156,12 +156,30 @@ def _schema_to_dataclass(variable_name: str, schema: dict) -> tuple:
         f"        return cls({from_dict_args})",
     ]
 
+    # Support dict-style access (parsed["key"] and parsed["first-name"] → parsed.first_name)
+    # so schema-backed Varis keep the same fallback contract as DotDict.
+    key_map_entries = ", ".join(f'"{key}": "{safe}"' for key, safe in field_map if key != safe)
+    if key_map_entries:
+        getitem_lines = [
+            "",
+            "    def __getitem__(self, key):",
+            f"        _key_map = {{{key_map_entries}}}",
+            "        return getattr(self, _key_map.get(key, key))",
+        ]
+    else:
+        getitem_lines = [
+            "",
+            "    def __getitem__(self, key):",
+            "        return getattr(self, key)",
+        ]
+
     lines = ["from dataclasses import dataclass, field", "", "@dataclass", f"class {class_name}:"]
     lines.extend(req_fields)
     lines.extend(opt_fields)
     if not req_fields and not opt_fields:
         lines.append("    pass")
     lines.extend(from_dict_lines)
+    lines.extend(getitem_lines)
     return class_name, "\n".join(lines)
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,5 @@
 import unittest
-from polyapi.utils import add_type_import_path, get_type_and_def, rewrite_reserved
+from polyapi.utils import add_type_import_path, get_type_and_def, rewrite_reserved, DotDict
 
 OPENAPI_FUNCTION = {
     "kind": "function",
@@ -107,3 +107,36 @@ class T(unittest.TestCase):
     def test_add_type_import_path_keeps_array_union_primitives_valid(self):
         arg_type = add_type_import_path("fooFunc", "Promise<string[] | null>")
         self.assertEqual(arg_type, "List[str] | None")
+
+
+class TestDotDict(unittest.TestCase):
+    def test_dot_access(self):
+        d = DotDict({"bye": "world"})
+        self.assertEqual(d.bye, "world")
+
+    def test_dict_access_still_works(self):
+        d = DotDict({"hello": "world"})
+        self.assertEqual(d["hello"], "world")
+
+    def test_nested_dot_access(self):
+        d = DotDict({"spider": {"bit": "man"}})
+        self.assertEqual(d.spider.bit, "man")
+
+    def test_nested_dict_access_still_works(self):
+        d = DotDict({"spider": {"bit": "man"}})
+        self.assertEqual(d["spider"]["bit"], "man")
+
+    def test_missing_key_raises_attribute_error(self):
+        d = DotDict({"hello": "world"})
+        with self.assertRaises(AttributeError):
+            _ = d.missing
+
+    def test_set_via_attribute(self):
+        d = DotDict({})
+        d.foo = "bar"
+        self.assertEqual(d["foo"], "bar")
+
+    def test_non_dict_values_returned_as_is(self):
+        d = DotDict({"count": 42, "tags": [1, 2, 3]})
+        self.assertEqual(d.count, 42)
+        self.assertEqual(d.tags, [1, 2, 3])

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -80,7 +80,34 @@ class T(unittest.TestCase):
         self.assertIn("hello: str", variable_str)
         self.assertIn("count: Optional[int]", variable_str)
         self.assertIn("-> \"DictVari\"", variable_str)
-        self.assertIn("return DictVari(**json.loads(resp.text))", variable_str)
+        self.assertIn("return DictVari._from_json(json.loads(resp.text))", variable_str)
+        self.assertIn("def __getitem__", variable_str)
+
+    def test_render_object_variable_with_schema_sanitizes_invalid_field_names(self):
+        schema_example = {**OBJECT_EXAMPLE}
+        schema_example["variable"] = {
+            **OBJECT_EXAMPLE["variable"],
+            "valueType": {
+                "kind": "object",
+                "schema": {
+                    "type": "object",
+                    "properties": {
+                        "first-name": {"type": "string"},
+                        "class": {"type": "string"},
+                        "valid_field": {"type": "integer"},
+                    },
+                    "required": ["first-name"],
+                }
+            }
+        }
+        variable_str = render_variable(schema_example)
+        self.assertIn("first_name: str", variable_str)
+        self.assertIn("class_: Optional[str]", variable_str)
+        self.assertIn("valid_field: Optional[int]", variable_str)
+        self.assertNotIn("first-name:", variable_str)
+        self.assertNotIn("class:", variable_str)
+        self.assertIn("'first-name': 'first_name'", variable_str)
+        self.assertIn("'class': 'class_'", variable_str)
 
     def test_render_string_variable_has_no_get_parsed(self):
         variable_str = render_variable(EXAMPLE)

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -21,8 +21,67 @@ EXAMPLE = {
         }
     }
 
+OBJECT_EXAMPLE = {
+        "type": "serverVariable",
+        "id": "abc123",
+        "name": "dict_vari",
+        "context": "test",
+        "description": "an object variable",
+        "visibilityMetadata": {
+            "visibility": "ENVIRONMENT"
+        },
+        "variable": {
+            "environmentId": "123818231",
+            "secrecy": "NONE",
+            "valueType": {
+                "kind": "object",
+            },
+            "value": '{"byebye": "world"}'
+        }
+    }
+
 
 class T(unittest.TestCase):
     def test_render_variable(self):
         variable_str = render_variable(EXAMPLE)
         self.assertIn("class test", variable_str)
+
+    def test_render_variable_string_uses_resp_text(self):
+        variable_str = render_variable(EXAMPLE)
+        self.assertIn("return resp.text", variable_str)
+        self.assertNotIn("DotDict", variable_str)
+
+    def test_render_object_variable_keeps_get_returning_str(self):
+        variable_str = render_variable(OBJECT_EXAMPLE)
+        self.assertIn("def get()", variable_str)
+        self.assertIn("return resp.text", variable_str)
+
+    def test_render_object_variable_adds_get_parsed(self):
+        variable_str = render_variable(OBJECT_EXAMPLE)
+        self.assertIn("def get_parsed()", variable_str)
+        self.assertIn("def get_parsed_async()", variable_str)
+
+    def test_render_object_variable_with_schema_generates_typed_dataclass(self):
+        schema_example = {**OBJECT_EXAMPLE}
+        schema_example["variable"] = {
+            **OBJECT_EXAMPLE["variable"],
+            "valueType": {
+                "kind": "object",
+                "schema": {
+                    "type": "object",
+                    "properties": {"hello": {"type": "string"}, "count": {"type": "integer"}},
+                    "required": ["hello"],
+                }
+            }
+        }
+        variable_str = render_variable(schema_example)
+        self.assertIn("@dataclass", variable_str)
+        self.assertIn("class DictVari:", variable_str)
+        self.assertIn("hello: str", variable_str)
+        self.assertIn("count: Optional[int]", variable_str)
+        self.assertIn("-> \"DictVari\"", variable_str)
+        self.assertIn("return DictVari(**json.loads(resp.text))", variable_str)
+
+    def test_render_string_variable_has_no_get_parsed(self):
+        variable_str = render_variable(EXAMPLE)
+        self.assertNotIn("get_parsed", variable_str)


### PR DESCRIPTION
Intended functionality as below: 
```
import json
import asyncio
from polyapi import poly, vari

async def some_func() ->None:
    # existing usage unchanged
    raw = await vari.test.dict_vari_no_secret.get_async()
    print(json.loads(raw)["hello"])

    # new: dot notation with get_parsed_async()
    parsed = await vari.test.dict_vari_no_secret.get_parsed_async()
    print(parsed.hello)
    print(parsed["hello"])  # dict access still works too

asyncio.run(some_func())
```

Plus something to put somewhere as a warning for ye who use dot notation in python: 

Any key that shadows a built-in dict method (keys, values, items, get, update, pop, etc.) won't be dot-accessible; need to use d["items"] for those which is why parsed["hello"] exists 

https://github.com/polyapi/poly-alpha/issues/5998