### PR TITLE
EN [#6292] py: pin stdlib_list to 0.11.1 and fix reload test isolation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "polyapi-python"
-version = "0.3.18.dev4"
+version = "0.3.18.dev5"
 description = "The Python Client for PolyAPI, the IPaaS by Developers for Developers"
 authors = [{ name = "PolyAPI", email = "support@polyapi.io" }]
 dependencies = [
@@ -12,7 +12,7 @@ dependencies = [
     "typing_extensions==4.12.2",
     "jsonschema-gentypes==2.10.0",
     "pydantic==2.8.0",
-    "stdlib_list==0.10.0",
+    "stdlib_list==0.11.1",
     "colorama==0.4.4",
     "python-socketio[asyncio_client]==5.11.1",
     "truststore==0.8.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ requests==2.32.3
 typing_extensions==4.12.2
 jsonschema-gentypes==2.10.0
 pydantic==2.8.0
-stdlib_list==0.10.0
+stdlib_list==0.11.1
 colorama==0.4.4
 python-socketio[asyncio_client]==5.11.1
 truststore==0.8.0

--- a/tests/test_poly_custom.py
+++ b/tests/test_poly_custom.py
@@ -7,7 +7,16 @@ from concurrent.futures import ThreadPoolExecutor
 def _reload_polyapi():
     sys.modules.pop("polyapi", None)
     sys.modules.pop("polyapi.cli", None)
-    return importlib.import_module("polyapi")
+    polyapi = importlib.import_module("polyapi")
+
+    for module_name, module in list(sys.modules.items()):
+        if not module_name.startswith("polyapi.") or module_name == "polyapi.cli":
+            continue
+        submodule_name = module_name.removeprefix("polyapi.")
+        if "." not in submodule_name:
+            setattr(polyapi, submodule_name, module)
+
+    return polyapi
 
 
 def test_import_polyapi_does_not_import_cli():
@@ -22,6 +31,14 @@ def test_cli_constants_shared_between_runtime_and_cli():
     cli_module = importlib.import_module("polyapi.cli")
 
     assert tuple(cli_module.CLI_COMMANDS) == cli_constants.CLI_COMMANDS
+
+
+def test_reload_preserves_existing_submodule_bindings():
+    rendered_spec = importlib.import_module("polyapi.rendered_spec")
+
+    polyapi = _reload_polyapi()
+
+    assert polyapi.rendered_spec is rendered_spec
 
 
 def test_poly_custom_nested_scopes_restore_previous_state():


### PR DESCRIPTION
#6292 Fix to support pytthon versions 3.10+ through 3.13