### PR TITLE
EN [#6292] py: deps: bump truststore for Python 3.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "polyapi-python"
-version = "0.3.18.dev6"
+version = "0.3.18.dev7"
 description = "The Python Client for PolyAPI, the IPaaS by Developers for Developers"
 authors = [{ name = "PolyAPI", email = "support@polyapi.io" }]
 dependencies = [
@@ -15,7 +15,7 @@ dependencies = [
     "stdlib_list==0.11.1",
     "colorama==0.4.4",
     "python-socketio[asyncio_client]==5.11.1",
-    "truststore==0.8.0",
+    "truststore==0.9.1",
     "httpx==0.28.1"
 ]
 readme = "README.md"

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ pydantic==2.8.0
 stdlib_list==0.11.1
 colorama==0.4.4
 python-socketio[asyncio_client]==5.11.1
-truststore==0.8.0
+truststore==0.9.1
 httpx==0.28.1

--- a/tests/test_dependency_pins.py
+++ b/tests/test_dependency_pins.py
@@ -1,0 +1,33 @@
+import re
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TRUSTSTORE_MINIMUM_PYTHON_313_VERSION = (0, 9, 1)
+
+
+def _parse_requirement_version(requirement: str) -> tuple[int, ...]:
+    match = re.fullmatch(r"truststore==(\d+)\.(\d+)\.(\d+)", requirement)
+    assert match is not None
+    return tuple(int(part) for part in match.groups())
+
+
+def test_truststore_pin_matches_between_dependency_surfaces():
+    requirements_lines = (REPO_ROOT / "requirements.txt").read_text(encoding="utf-8").splitlines()
+    requirements_pin = next(line for line in requirements_lines if line.startswith("truststore=="))
+
+    pyproject_text = (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    pyproject_match = re.search(r'"(truststore==\d+\.\d+\.\d+)"', pyproject_text)
+    assert pyproject_match is not None
+    pyproject_pin = pyproject_match.group(1)
+
+    assert requirements_pin == pyproject_pin
+
+
+def test_truststore_pin_supports_python_313_ssl_chain_api():
+    requirements_lines = (REPO_ROOT / "requirements.txt").read_text(encoding="utf-8").splitlines()
+    requirements_pin = next(line for line in requirements_lines if line.startswith("truststore=="))
+
+    if sys.version_info >= (3, 13):
+        assert _parse_requirement_version(requirements_pin) >= TRUSTSTORE_MINIMUM_PYTHON_313_VERSION


### PR DESCRIPTION
ticket -> https://github.com/polyapi/poly-alpha/issues/6292
Found another dep issue (truststore) with python 3.13.
This bumps truststore from `0.8.0` to `0.9.1`