### PR TITLE
EN correct Python SDK local $ref type generation for server functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .DS_Store
 
 # Pip
+/build/
 dist/
 polyapi_python.egg-info/
 

--- a/polyapi/utils.py
+++ b/polyapi/utils.py
@@ -1,7 +1,7 @@
 import keyword
 import re
 import os
-from urllib.parse import urlparse
+from urllib.parse import unquote, urlparse
 from typing import Tuple, List, Optional, cast
 from colorama import Fore, Style
 from polyapi.constants import BASIC_PYTHON_TYPES
@@ -299,11 +299,29 @@ def _maybe_add_fallback_schema_name(a: PropertySpecification):
     # Handle cases where type might be missing
     if not a.get("type"):
         return
-    
+
     if a["type"].get("kind") == "object" and a["type"].get("schema"):
         schema = a["type"].get("schema", {})
-        if not schema.get("title") and not schema.get("name") and a.get("name"):
-            schema["title"] = a["name"].title()
+        title = schema.get("title") or schema.get("name")
+        if not title and a.get("name"):
+            title = a["name"].title()
+            schema["title"] = title
+
+        reference = schema.get("$ref")
+        definitions = schema.get("definitions")
+        reference_prefix = "#/definitions/"
+        if not isinstance(title, str):
+            return
+        if not isinstance(reference, str) or not reference.startswith(reference_prefix):
+            return
+        if not isinstance(definitions, dict):
+            return
+
+        definition_name = unquote(reference[len(reference_prefix):])
+        definition_name = definition_name.replace("~1", "/").replace("~0", "~")
+        definition = definitions.get(definition_name)
+        if isinstance(definition, dict):
+            definition.setdefault("title", title)
 
 
 def _clean_description(text: str) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "polyapi-python"
-version = "0.3.20.dev0"
+version = "0.3.20.dev1"
 description = "The Python SDK for the integration platform PolyAPI"
 authors = [{ name = "PolyAPI", email = "support@polyapi.io" }]
 dependencies = [

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1,8 +1,12 @@
 import unittest
+import copy
 import os
 import shutil
 import importlib.util
+import subprocess
+import sys
 import tempfile
+from typing import cast
 from unittest.mock import patch, MagicMock
 from polyapi.typedefs import SpecificationDto
 from polyapi.utils import get_type_and_def, rewrite_reserved, to_type_module_alias
@@ -102,6 +106,144 @@ MINIMAL_FUNCTION_SPEC = {
         # Note: no "arguments" or "returnType" fields
     }
 }
+
+MEWS_HEADERS_SPECS = [
+    (
+        {
+            "id": "6979c3e1-4d59-4867-91b7-4d394fe9e34a",
+            "type": "serverFunction",
+            "context": "gha.mews.v1",
+            "name": "generalEvents",
+            "description": "Sanitized Mews headers regression fixture",
+            "language": "javascript",
+            "function": {
+                "arguments": [
+                    {
+                        "name": "headers",
+                        "description": "",
+                        "required": True,
+                        "type": {
+                            "kind": "object",
+                            "schema": {
+                                "$ref": "#/definitions/Gha.Mews.V1.GeneralEvents%24Headers.Argument",
+                                "$schema": "http://json-schema.org/draft-07/schema#",
+                                "definitions": {
+                                    "Gha.Mews.V1.GeneralEvents$Headers.Argument": {
+                                        "type": "object",
+                                        "additionalProperties": {},
+                                    },
+                                },
+                            },
+                        },
+                    },
+                ],
+                "returnType": {"kind": "void"},
+            },
+        },
+        "Headers",
+        "Headers = dict[str, str | int | float | dict[str, Any] | list[Any] | bool | None]",
+    ),
+    (
+        {
+            "id": "d8230ba3-b1da-4d2f-8e47-97114d8a3f37",
+            "type": "serverFunction",
+            "context": "gha.mews.v1",
+            "name": "membersSearch",
+            "description": "Sanitized Mews headers regression fixture",
+            "language": "javascript",
+            "function": {
+                "arguments": [
+                    {
+                        "name": "_headers",
+                        "description": "",
+                        "required": True,
+                        "type": {
+                            "kind": "object",
+                            "schema": {
+                                "$ref": "#/definitions/Gha.Mews.V1.MembersSearch%24Headers.Argument",
+                                "$schema": "http://json-schema.org/draft-07/schema#",
+                                "definitions": {
+                                    "Gha.Mews.V1.MembersSearch$Headers.Argument": {
+                                        "type": "object",
+                                        "additionalProperties": {},
+                                    },
+                                },
+                            },
+                        },
+                    },
+                ],
+                "returnType": {"kind": "void"},
+            },
+        },
+        "_Headers",
+        "_Headers = dict[str, str | int | float | dict[str, Any] | list[Any] | bool | None]",
+    ),
+    (
+        {
+            "id": "3037a373-291f-4b87-9966-b3d125ffee26",
+            "type": "serverFunction",
+            "context": "gha.mews.v1",
+            "name": "membershipsCreate",
+            "description": "Sanitized Mews headers regression fixture",
+            "language": "javascript",
+            "function": {
+                "arguments": [
+                    {
+                        "name": "_headers",
+                        "description": "",
+                        "required": True,
+                        "type": {
+                            "kind": "object",
+                            "schema": {
+                                "$ref": "#/definitions/Gha.Mews.V1.MembershipsCreate%24Headers.Argument",
+                                "$schema": "http://json-schema.org/draft-07/schema#",
+                                "definitions": {
+                                    "Gha.Mews.V1.MembershipsCreate$Headers.Argument": {
+                                        "type": "object",
+                                        "additionalProperties": {"type": "string"},
+                                    },
+                                },
+                            },
+                        },
+                    },
+                ],
+                "returnType": {"kind": "void"},
+            },
+        },
+        "_Headers",
+        "_Headers = dict[str, str]",
+    ),
+    (
+        {
+            "id": "63c65574-26bf-4b10-a301-06ce02dad548",
+            "type": "serverFunction",
+            "context": "gha.mews.v1",
+            "name": "membershipsList",
+            "description": "Sanitized Mews headers regression fixture",
+            "language": "javascript",
+            "function": {
+                "arguments": [
+                    {
+                        "name": "_headers",
+                        "description": "",
+                        "required": True,
+                        "type": {
+                            "kind": "object",
+                            "schema": {
+                                "$schema": "http://json-schema.org/draft-07/schema#",
+                                "type": "object",
+                                "additionalProperties": {},
+                            },
+                        },
+                    },
+                ],
+                "returnType": {"kind": "void"},
+            },
+        },
+        "_Headers",
+        "_Headers = dict[str, str | int | float | dict[str, Any] | list[Any] | bool | None]",
+    ),
+]
 
 
 class T(unittest.TestCase):
@@ -704,3 +846,54 @@ def test_nested_function() -> schemas.api.v1.user.profile:
                 f"-> {type_module_alias}.{spec['name']}Response",
                 init_content,
             )
+
+    def test_mews_headers_schemas_generate_referenced_type_aliases(self):
+        for fixture, expected_symbol, expected_definition in MEWS_HEADERS_SPECS:
+            with self.subTest(function=fixture["name"]):
+                spec = copy.deepcopy(fixture)
+                func_str, func_type_defs = render_spec(cast(SpecificationDto, spec))
+                type_module_alias = to_type_module_alias(spec["name"])
+
+                self.assertIn(
+                    f"{spec['function']['arguments'][0]['name']}: "
+                    f"{type_module_alias}.{expected_symbol}",
+                    func_str,
+                )
+                self.assertIn(expected_definition, func_type_defs)
+
+    def test_mews_headers_reference_preserves_explicit_definition_title(self):
+        spec = copy.deepcopy(MEWS_HEADERS_SPECS[1][0])
+        schema = spec["function"]["arguments"][0]["type"]["schema"]
+        definition = schema["definitions"]["Gha.Mews.V1.MembersSearch$Headers.Argument"]
+        definition["title"] = "ExistingTitle"
+
+        render_spec(cast(SpecificationDto, spec))
+
+        self.assertEqual(definition["title"], "ExistingTitle")
+
+    def test_mews_headers_generated_package_imports_in_fresh_process(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            package_name = "generated_mews"
+            package_dir = os.path.join(temp_dir, package_name)
+            os.makedirs(package_dir)
+
+            for fixture, _, _ in MEWS_HEADERS_SPECS:
+                spec = copy.deepcopy(fixture)
+                add_function_file(
+                    package_dir,
+                    spec["name"],
+                    cast(SpecificationDto, spec),
+                )
+
+            repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+            result = subprocess.run(
+                [sys.executable, "-c", f"import {package_name}"],
+                cwd=temp_dir,
+                env={
+                    "PYTHONPATH": os.pathsep.join([temp_dir, repo_root]),
+                },
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)


### PR DESCRIPTION
asana -> https://app.asana.com/1/1204270330582500/project/1215930030523258/task/1216995816477520?focus=true

Fix Python SDK generation for top-level local ref schemas whose referenced definition lacks a title. Propagates the fallback argument name, preserves explicit titles, and adds regression coverage for encoded keys and generated imports.